### PR TITLE
Improve the log_summary displayed for a test

### DIFF
--- a/distbench.proto
+++ b/distbench.proto
@@ -77,7 +77,7 @@ message TestResult {
   optional DistributedSystemDescription traffic_config = 1;
   optional ServiceEndpointMap placement = 2;
   optional ServiceLogs service_logs = 3;
-  optional string log_summary = 4;
+  repeated string log_summary = 4;
 }
 
 // Logs for all a test configs in a test sequence:

--- a/distbench_test_sequencer.cc
+++ b/distbench_test_sequencer.cc
@@ -151,9 +151,11 @@ grpc::Status TestSequencer::DoRunTestSequence(grpc::ServerContext* context,
     }
     auto maybe_result = DoRunTest(context, test);
     if (maybe_result.ok()) {
-      std::string summary = SummarizeTestResult(maybe_result.value());
-      maybe_result->set_log_summary(summary);
-      LOG(INFO) << summary;
+      auto summary = SummarizeTestResult(maybe_result.value());
+      for (auto s: summary) {
+        maybe_result->add_log_summary(s);
+        LOG(INFO) << s;
+      }
       *response->add_test_results() = maybe_result.value();
     } else {
       return grpc::Status(grpc::StatusCode::ABORTED,

--- a/distbench_test_sequencer_test.cc
+++ b/distbench_test_sequencer_test.cc
@@ -267,10 +267,11 @@ TEST(DistBenchTestSequencer, clique_test) {
   ASSERT_EQ(results.test_results().size(), 1);
   auto& test_results = results.test_results(0);
 
-  const auto &log_summary = test_results.log_summary();
-  size_t pos = log_summary.find("N: ") + 3;
+  const auto& log_summary = test_results.log_summary();
+  const auto& latency_summary = log_summary[1];
+  size_t pos = latency_summary.find("N: ") + 3;
   ASSERT_NE(pos, std::string::npos);
-  const std::string N_value = log_summary.substr(pos);
+  const std::string N_value = latency_summary.substr(pos);
 
   std::string N_value2 = N_value.substr(0, N_value.find(' '));
   int N;

--- a/distbench_utils.h
+++ b/distbench_utils.h
@@ -55,7 +55,7 @@ void InitLibs(const char* argv0);
 
 std::string Hostname();
 
-std::string SummarizeTestResult(const TestResult& test_result);
+std::vector<std::string> SummarizeTestResult(const TestResult& test_result);
 
 grpc::Status Annotate(const grpc::Status& status, std::string_view context);
 


### PR DESCRIPTION
On top of the latencies, it will also report:
- RPCs and bandwidths between pairs of instance
- Aggregate bandwidth results for each instance
- The total time spend, the total amount of payload transmitted (&bw), total
number of RPCs (&rate).

The output report looks as follows (once breaken up by \n):

RPC latency summary:
client_server_rpc: N: 12500 min: 240634ns median: 744671ns 90%: 1112991ns 99%: 1812125ns 99.9%: 15640625ns max: 19948356ns
Communication summary:
  client/0 -> server/0: RPCs: 2500 (1.26 kQPS) Request: 0.2 MiB/s Response: 315.1 MiB/s
  client/1 -> server/0: RPCs: 2500 (1.26 kQPS) Request: 0.2 MiB/s Response: 315.1 MiB/s
  client/2 -> server/0: RPCs: 2500 (1.26 kQPS) Request: 0.2 MiB/s Response: 315.1 MiB/s
  client/3 -> server/0: RPCs: 2500 (1.26 kQPS) Request: 0.2 MiB/s Response: 315.1 MiB/s
  client/4 -> server/0: RPCs: 2500 (1.26 kQPS) Request: 0.2 MiB/s Response: 315.1 MiB/s
Instance summary:
  client/0: Tx: 0.2 MiB/s, Rx:315.1 MiB/s
  client/1: Tx: 0.2 MiB/s, Rx:315.1 MiB/s
  client/2: Tx: 0.2 MiB/s, Rx:315.1 MiB/s
  client/3: Tx: 0.2 MiB/s, Rx:315.1 MiB/s
  client/4: Tx: 0.2 MiB/s, Rx:315.1 MiB/s
  server/0: Tx: 1575.7 MiB/s, Rx:1.2 MiB/s

Total time: 1.983s Total Tx: 3127 MiB (1576.9 MiB/s), Total Nb RPCs: 12500 (6.30 kQPS)