### PR TITLE
Fix the truncated log issue when some nodes finish early

### DIFF
--- a/distbench.proto
+++ b/distbench.proto
@@ -113,7 +113,7 @@ message TestResult {
   repeated string log_summary = 100;
 }
 
-message RunTrafficResponse {
+message GetTrafficResultResponse {
   optional ServiceLogs service_logs = 1;
   map<string, RUsageStats> node_usages = 2;
 }
@@ -160,15 +160,24 @@ message ServiceEndpointMap {
 
 message IntroducePeersResult {}
 
+
 message RunTrafficRequest {}
+
+message RunTrafficResponse {}
+
+
+message GetTrafficResultRequest {}
+
 
 message CancelTrafficRequest {}
 
 message CancelTrafficResult {}
 
+
 message ShutdownNodeRequest {}
 
 message ShutdownNodeResult {}
+
 
 service DistBenchNodeManager {
   // Sets up services prior to running traffic:
@@ -177,8 +186,11 @@ service DistBenchNodeManager {
   // Introduces NodeEngines to each other.
   rpc IntroducePeers(ServiceEndpointMap) returns (IntroducePeersResult) {}
 
-  // Runs traffic and monitors performance logs:
+  // Runs traffic:
   rpc RunTraffic(RunTrafficRequest) returns (RunTrafficResponse) {}
+
+  // Get the RunTraffic performance logs:
+  rpc GetTrafficResult(GetTrafficResultRequest) returns (GetTrafficResultResponse) {}
 
   // Cancels a currently running traffic pattern immediately:
   rpc CancelTraffic(CancelTrafficRequest) returns (CancelTrafficResult) {}

--- a/distbench_node_manager.h
+++ b/distbench_node_manager.h
@@ -50,6 +50,10 @@ class NodeManager final : public DistBenchNodeManager::Service {
                           const RunTrafficRequest* request,
                           RunTrafficResponse* response) override;
 
+  grpc::Status GetTrafficResult(grpc::ServerContext* context,
+                                const GetTrafficResultRequest* request,
+                                GetTrafficResultResponse* response) override;
+
   grpc::Status CancelTraffic(grpc::ServerContext* context,
                              const CancelTrafficRequest* request,
                              CancelTrafficResult* response) override;
@@ -89,6 +93,8 @@ class NodeManager final : public DistBenchNodeManager::Service {
   NodeManagerOpts opts_;
   absl::Notification shutdown_requested_;
   NodeConfig config_;
+
+  struct rusage rusage_start_test_;
 };
 
 }  // namespace distbench

--- a/distbench_test_sequencer.h
+++ b/distbench_test_sequencer.h
@@ -72,7 +72,7 @@ class TestSequencer final : public DistBenchTestSequencer::Service {
       const std::map<std::string, std::set<std::string>>& node_service_map,
       ServiceEndpointMap service_map);
 
-  absl::StatusOr<RunTrafficResponse> RunTraffic(
+  absl::StatusOr<GetTrafficResultResponse> RunTraffic(
       const std::map<std::string, std::set<std::string>>& node_service_map);
 
   void CancelTraffic() ABSL_LOCKS_EXCLUDED(mutex_);


### PR DESCRIPTION
RunTraffic can finish early on some nodes and return only partial
results, this wait for all the RunTraffic to complete before gathering
the results.