### PR TITLE
Avoid using std::vector for packed samples, as it still initializes its

### DIFF
--- a/distbench_engine.cc
+++ b/distbench_engine.cc
@@ -574,7 +574,8 @@ void DistBenchEngine::RunActionList(
 
   // Allocate peer_logs_ for performance gathering, if needed:
   if (s.action_list->has_rpcs) {
-    s.packed_samples_.resize(s.action_list->proto.max_rpc_samples());
+    s.packed_samples_size_ = s.action_list->proto.max_rpc_samples();
+    s.packed_samples_.reset(new PackedLatencySample[s.packed_samples_size_]);
     s.remaining_initial_samples_ = s.action_list->proto.max_rpc_samples();
     absl::MutexLock m(&s.action_mu);
     s.peer_logs_.resize(peers_.size());
@@ -693,13 +694,15 @@ void DistBenchEngine::ActionListState::WaitForAllPendingActions() {
 
 void DistBenchEngine::ActionListState::UnpackLatencySamples() {
   absl::MutexLock m(&action_mu);
-  if (packed_sample_number_ < packed_samples_.size()) {
-    packed_samples_.resize(packed_sample_number_);
-  } else if (packed_sample_number_ > packed_samples_.size()){
+  if (packed_sample_number_ <= packed_samples_size_) {
+    packed_samples_size_ = packed_sample_number_;
+  } else {
     // If we did Reservoir sampling, we should sort the data:
-    std::sort(packed_samples_.begin(), packed_samples_.end());
+    std::sort(packed_samples_.get(),
+              packed_samples_.get() + packed_samples_size_);
   }
-  for (const auto& packed_sample : packed_samples_) {
+  for (size_t i = 0; i < packed_samples_size_; ++i) {
+    const auto& packed_sample = packed_samples_[i];
     CHECK_LT(packed_sample.service_type, peer_logs_.size());
     auto& service_log = peer_logs_[packed_sample.service_type];
     CHECK_LT(packed_sample.instance, service_log.size());
@@ -727,11 +730,11 @@ void DistBenchEngine::ActionListState::RecordLatency(
     ClientRpcState* state) {
   // If we are using packed samples we avoid grabbing a mutex, but are limited
   // in how many samples total we can collect:
-  if (!packed_samples_.empty()) {
+  if (packed_samples_size_) {
     const size_t sample_number = atomic_fetch_add_explicit(
         &packed_sample_number_, 1, std::memory_order_relaxed);
     size_t index = sample_number;
-    if (index < packed_samples_.size()) {
+    if (index < packed_samples_size_) {
       RecordPackedLatency(
           sample_number, index, rpc_index, service_type, instance, state);
       atomic_fetch_sub_explicit(
@@ -741,7 +744,7 @@ void DistBenchEngine::ActionListState::RecordLatency(
     // Simple Reservoir Sampling:
     absl::BitGen bitgen;
     index = absl::Uniform(absl::IntervalClosedClosed, bitgen, 0UL, index);
-    if (index >= packed_samples_.size()) {
+    if (index >= packed_samples_size_) {
       // Histogram per [rpc_index, service] would be ideal here:
       // Also client rpc state could point to the destination stats instead
       // of requiring us to look them up below.

--- a/distbench_engine.h
+++ b/distbench_engine.h
@@ -195,7 +195,8 @@ class DistBenchEngine : public ConnectionSetup::Service {
 
     std::vector<std::vector<PeerPerformanceLog>> peer_logs_
       ABSL_GUARDED_BY(action_mu);
-    std::vector<PackedLatencySample> packed_samples_;
+    std::unique_ptr<PackedLatencySample[]> packed_samples_;
+    size_t packed_samples_size_ = 0;
     std::atomic<size_t> packed_sample_number_ = 0;
     std::atomic<size_t> remaining_initial_samples_;
     absl::Mutex reservoir_sample_lock_;

--- a/traffic_config.proto
+++ b/traffic_config.proto
@@ -72,7 +72,7 @@ message ActionList {
   // If more than max_rpc_samples rpcs are performed then distbench will
   // choose the samples to retain via reservoir sampling.
   // Setting this to zero will retain all samples, but may hurt performance.
-  optional int64 max_rpc_samples = 3 [default = 1048576];
+  optional int64 max_rpc_samples = 3 [default = 0];
 }
 
 message NamedSetting {


### PR DESCRIPTION
contents even if they are trivially constructible. Also avoid enabling
the reservoir sampling by default.