### PR TITLE
Make RpcHandler return a std::function

### DIFF
--- a/distbench_engine.h
+++ b/distbench_engine.h
@@ -227,7 +227,7 @@ class DistBenchEngine : public ConnectionSetup::Service {
   std::vector<ActionListTableEntry> action_lists_;
 
   absl::Status ConnectToPeers();
-  void RpcHandler(ServerRpcState* state);
+  std::function<void ()> RpcHandler(ServerRpcState* state);
 
   int get_payload_size(const std::string& name);
 

--- a/protocol_driver.h
+++ b/protocol_driver.h
@@ -64,7 +64,8 @@ class ProtocolDriver {
       const ProtocolDriverOptions &pd_opts, int* port) = 0;
 
   virtual void SetHandler(
-      std::function<void(ServerRpcState* state)> handler) = 0;
+      std::function<std::function<void ()> (ServerRpcState* state)> handler)
+      = 0;
   virtual void SetNumPeers(int num_peers) = 0;
 
   // Allocate local resources that are needed to establish a connection

--- a/protocol_driver_grpc.cc
+++ b/protocol_driver_grpc.cc
@@ -25,7 +25,9 @@ class TrafficService : public Traffic::Service {
  public:
   ~TrafficService() override {}
 
-  void SetHandler (std::function<void(ServerRpcState* state)> handler) {
+  void SetHandler (
+      std::function<std::function<void ()> (ServerRpcState* state)> handler
+      ) {
     handler_ = handler;
   }
 
@@ -45,7 +47,7 @@ class TrafficService : public Traffic::Service {
   }
 
  private:
-  std::function<void(ServerRpcState* state)> handler_;
+  std::function<std::function<void ()> (ServerRpcState* state)> handler_;
 };
 
 }  // anonymous namespace
@@ -84,7 +86,8 @@ absl::Status ProtocolDriverGrpc::Initialize(
 }
 
 void ProtocolDriverGrpc::SetHandler(
-    std::function<void(ServerRpcState* state)> handler) {
+    std::function<std::function<void ()> (ServerRpcState* state)> handler
+    ) {
   static_cast<TrafficService*>(traffic_service_.get())->SetHandler(handler);
 }
 

--- a/protocol_driver_grpc.h
+++ b/protocol_driver_grpc.h
@@ -29,7 +29,9 @@ class ProtocolDriverGrpc : public ProtocolDriver {
   absl::Status Initialize(
       const ProtocolDriverOptions &pd_opts, int* port) override;
 
-  void SetHandler(std::function<void(ServerRpcState* state)> handler) override;
+  void SetHandler(
+      std::function<std::function<void ()> (ServerRpcState* state)> handler
+      ) override;
   void SetNumPeers(int num_peers) override;
 
   // Connects to the actual GRPC service.

--- a/protocol_driver_grpc_async_callback.h
+++ b/protocol_driver_grpc_async_callback.h
@@ -29,7 +29,9 @@ class ProtocolDriverGrpcAsyncCallback : public ProtocolDriver {
   absl::Status Initialize(
       const ProtocolDriverOptions &pd_opts, int* port) override;
 
-  void SetHandler(std::function<void(ServerRpcState* state)> handler) override;
+  void SetHandler(
+      std::function<std::function<void ()> (ServerRpcState* state)> handler
+      ) override;
   void SetNumPeers(int num_peers) override;
 
   // Connects to the actual GRPC service.

--- a/protocol_driver_test.cc
+++ b/protocol_driver_test.cc
@@ -37,6 +37,7 @@ TEST_P(ProtocolDriverTest, initialize) {
   pd->SetNumPeers(1);
   pd->SetHandler([](ServerRpcState *s) {
     ADD_FAILURE() << "should not get here";
+    return std::function<void ()>();
   });
 }
 
@@ -47,7 +48,10 @@ TEST_P(ProtocolDriverTest, get_addr) {
   ASSERT_OK(pd->Initialize(pdo, &port));
   pd->SetNumPeers(1);
   std::atomic<int> server_rpc_count = 0;
-  pd->SetHandler([&](ServerRpcState *s) { ++server_rpc_count; });
+  pd->SetHandler([&](ServerRpcState *s) {
+    ++server_rpc_count;
+    return std::function<void ()>();
+  });
   std::string addr = pd->HandlePreConnect("", 0).value();
   ASSERT_EQ(server_rpc_count, 0);
 }
@@ -59,7 +63,10 @@ TEST_P(ProtocolDriverTest, get_set_addr) {
   ASSERT_OK(pd->Initialize(pdo, &port));
   pd->SetNumPeers(1);
   std::atomic<int> server_rpc_count = 0;
-  pd->SetHandler([&](ServerRpcState *s) { ++server_rpc_count; });
+  pd->SetHandler([&](ServerRpcState *s) {
+    ++server_rpc_count;
+    return std::function<void ()>();
+  });
   std::string addr = pd->HandlePreConnect("", 0).value();
   ASSERT_OK(pd->HandleConnect(addr, 0));
   ASSERT_EQ(server_rpc_count, 0);
@@ -79,18 +86,17 @@ TEST_P(ProtocolDriverTest, invoke) {
       s->request->SerializeToString(&str);
       s->send_response();
       if (s->free_state) s->free_state();
+      return std::function<void ()>();
     } else {
-      RunRegisteredThread(
-        "FakeServerThread",
-        [=]() {
-          sleep(1);
-          std::string str;
-          s->request->SerializeToString(&str);
-          s->send_response();
-          if (s->free_state) s->free_state();
-        }).detach();
+      std::function<void ()> fct = [=]() {
+        sleep(1);
+        std::string str;
+        s->request->SerializeToString(&str);
+        s->send_response();
+        if (s->free_state) s->free_state();
+      };
+      return fct;
     }
-
   });
   std::string addr = pd->HandlePreConnect("", 0).value();
   ASSERT_OK(pd->HandleConnect(addr, 0));
@@ -121,6 +127,7 @@ TEST_P(ProtocolDriverTest, self_echo) {
     s->response.set_payload(s->request->payload());
     s->send_response();
     if (s->free_state) s->free_state();
+    return std::function<void ()>();
   });
   std::string addr = pd->HandlePreConnect("", 0).value();
   ASSERT_OK(pd->HandleConnect(addr, 0));
@@ -151,12 +158,14 @@ TEST_P(ProtocolDriverTest, echo) {
     s->response.set_payload(s->request->payload());
     s->send_response();
     if (s->free_state) s->free_state();
+    return std::function<void ()>();
   });
   int port2 = 0;
   ASSERT_OK(pd1->Initialize(pdo, &port2));
   pd1->SetNumPeers(1);
   pd1->SetHandler([&](ServerRpcState *s) {
     ADD_FAILURE() << "should not get here";
+    return std::function<void ()>();
   });
   std::string addr1 = pd1->HandlePreConnect("", 0).value();
   std::string addr2 = pd2->HandlePreConnect("", 0).value();
@@ -188,12 +197,14 @@ void Echo(benchmark::State &state, ProtocolDriverOptions opts) {
     s->response.set_payload(s->request->payload());
     s->send_response();
     if (s->free_state) s->free_state();
+    return std::function<void ()>();
   });
   int port2 = 0;
   ASSERT_OK(pd1->Initialize(opts, &port2));
   pd1->SetNumPeers(1);
   pd1->SetHandler([&](ServerRpcState *s) {
     ADD_FAILURE() << "should not get here";
+    return std::function<void ()>();
   });
   std::string addr1 = pd1->HandlePreConnect("", 0).value();
   std::string addr2 = pd2->HandlePreConnect("", 0).value();


### PR DESCRIPTION
If have_dedicated_thread==false, make RpcHandler return a std::function
with the extra work to be performed by the protocol driver on an extra
thread.