### PR TITLE
Increase 'max_test_duration' to prevent timeout

### DIFF
--- a/workloads/multi_level_rpc_pattern.sh
+++ b/workloads/multi_level_rpc_pattern.sh
@@ -105,7 +105,7 @@ echo The test will run for about $TIME_SECONDS seconds
 $DISTBENCH_BIN run_tests --test_sequencer=$SEQUENCER \
                          --outfile="$OUTPUT_FILE" \
                          --binary_output \
-                         --max_test_duration=$(( TIME_SECONDS + 30 ))s \
+                         --max_test_duration=$(( TIME_SECONDS + 100 ))s \
 <<EOF
 tests {
   name: "multi_level_rpc;qps=$QPS;proto=$PROTOCOL_DRIVER;scale=$LEAF_COUNT"


### PR DESCRIPTION
Increase 'max_test_duration' to prevent test-timeout on GCP.
