### PR TITLE
Shutdown services inside of the GetTrafficResultRequest handler.

### DIFF
--- a/distbench.proto
+++ b/distbench.proto
@@ -166,7 +166,9 @@ message RunTrafficRequest {}
 message RunTrafficResponse {}
 
 
-message GetTrafficResultRequest {}
+message GetTrafficResultRequest {
+  optional bool clear_services = 1;
+}
 
 
 message CancelTrafficRequest {}

--- a/distbench_node_manager.cc
+++ b/distbench_node_manager.cc
@@ -163,7 +163,7 @@ grpc::Status NodeManager::GetTrafficResult(
     grpc::ServerContext* context,
     const GetTrafficResultRequest* request,
     GetTrafficResultResponse* response) {
-  absl::ReaderMutexLock m (&mutex_);
+  absl::MutexLock m (&mutex_);
 
   for (const auto& service_engine : service_engines_) {
     auto log = service_engine.second->GetLogs();
@@ -173,6 +173,12 @@ grpc::Status NodeManager::GetTrafficResult(
     }
   }
 
+  if (request->clear_services()) {
+    for (const auto& service_engine : service_engines_) {
+      service_engine.second->CancelTraffic();
+    }
+    ClearServices();
+  }
   (*response->mutable_node_usages())[config_.node_alias()] =
       GetRUsageStatsFromStructs(rusage_start_test_, DoGetRusage());
 

--- a/distbench_test_sequencer.cc
+++ b/distbench_test_sequencer.cc
@@ -508,6 +508,7 @@ absl::StatusOr<GetTrafficResultResponse> TestSequencer::RunTraffic(
     std::chrono::system_clock::time_point deadline =
       std::chrono::system_clock::now() + std::chrono::seconds(60);
     rpc_state.context.set_deadline(deadline);
+    rpc_state.request.set_clear_services(true);
     rpc_state.rpc = rpc_state.node->stub->AsyncGetTrafficResult(
           &rpc_state.context, rpc_state.request, &cq);
     rpc_state.rpc->Finish(&rpc_state.response, &rpc_state.status, &rpc_state);


### PR DESCRIPTION
This avoids zombie protocol drivers hangin around between tests,