### PR TITLE
Add support for the test_timeout attribute

### DIFF
--- a/distbench_test_sequencer.h
+++ b/distbench_test_sequencer.h
@@ -73,7 +73,8 @@ class TestSequencer final : public DistBenchTestSequencer::Service {
       ServiceEndpointMap service_map);
 
   absl::StatusOr<GetTrafficResultResponse> RunTraffic(
-      const std::map<std::string, std::set<std::string>>& node_service_map);
+      const std::map<std::string, std::set<std::string>>& node_service_map,
+      int64_t timeout_seconds);
 
   void CancelTraffic() ABSL_LOCKS_EXCLUDED(mutex_);
 

--- a/distbench_utils.cc
+++ b/distbench_utils.cc
@@ -351,4 +351,24 @@ int64_t GetNamedSettingInt64(
   return default_value;
 }
 
+absl::StatusOr<int64_t> GetNamedAttributeInt64(
+    const distbench::DistributedSystemDescription &test,
+    absl::string_view name,
+    int64_t default_value) {
+  auto attributes = test.attributes();
+  auto it = attributes.find(name);
+  if (it == attributes.end()) {
+    return default_value;
+  }
+  int64_t value;
+  bool success = absl::SimpleAtoi(it->second, &value);
+  if (success) {
+    return value;
+  } else {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Cannot convert test attribute ", name, " value (", it->second,
+        ") to int."));
+  }
+}
+
 }  // namespace distbench

--- a/distbench_utils.h
+++ b/distbench_utils.h
@@ -90,6 +90,11 @@ int64_t GetNamedSettingInt64(
     absl::string_view name,
     int64_t default_value);
 
+absl::StatusOr<int64_t> GetNamedAttributeInt64(
+    const distbench::DistributedSystemDescription &test,
+    absl::string_view name, int64_t default_value);
+
+
 }  // namespace distbench
 
 #endif  // DISTBENCH_DISTBENCH_UTILS_H_

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -39,18 +39,26 @@ the execution is completed, a summary will be displayed. If a result filename is
 specified, the TestResult will also be saved.
 
 ``` bash
-distbench run_tests [--infile test_sequence.proto_text] [--outfile result.proto] [--test_sequencer=host:port] [--binary_output]
+distbench run_tests [--infile test_sequence.proto_text]
+                    [--outfile result.proto]
+                    [--test_sequencer=host:port]
+                    [--binary_output]
+                    [--max_test_duration=duration]
+                    --test_sequencer=host:port
 ```
 
 Options:
 - `--test_sequencer=h:p`: The host:port of the `test_sequencer` to connect to.
 - `--binary_output`: Save the test result protobuf in binary
 - `--infile test_sequence.proto_text`: The protobuf filename of the test
-  sequence to submit to the test sequencer.
+  sequence to submit to the test sequencer (default to /dev/stdin).
 - `--outfile result.proto`: The protobuf filename that is used to save the test
   result.  Specify `--binary_output` to save in binary mode. An empty filename
   (--outfile "") will suppress the output (only the test summary will be
   displayed).
+- `--max_test_duration=duration`: Set the maximum time for each test
+  specified in the test sequence proto. If unspecified by this flag or in the
+  test sequence proto, it will default to 1 hour.
 
 ## help
 

--- a/docs/distbench-test-format.md
+++ b/docs/distbench-test-format.md
@@ -28,6 +28,8 @@ in this document.
 - `rpc_descriptions`: describe a RPC to perform, including the type of payload
   and fanout involved.
 - `payload_descriptions`: define a payload that can be associated with an RPC.
+- `attributes`:
+  - `test_timeout`: Maximum time to run the test in seconds.
 
 **Note:** by convention, repeated fields in the proto are described by plural
 names. So a `services` block describes a single service, but there may be


### PR DESCRIPTION
Add the support for the attribute test_timeout for test sequences.
  attributes: { key: 'test_timeout' value: '30' }

It is tested at two levels:
- individually for each test in RunTraffic
- globally with the runtests (using the sum of all timeouts specified)