### PR TITLE
Format files with clang-format Google style and provide pre-commit hook to help enforcing the style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+DerivePointerAlignment: false

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ basicprof:
 	bazel-bin/protocol_driver_test
 	gprof bazel-bin/protocol_driver_test
 
+clang-format:
+	for file in *.{cc,h}; do\
+		clang-format -i -style=file $${file};\
+	done
+
 all:
 	bazel build :all
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Use Distbench to:
 - [Distbench Test Builder](test_builder/README.md): Tool to build and execute
   parametric distbench test sequences.
 - [Distbench FAQs](docs/faq.md)
+- [Git Hooks](git_hooks/README.md)
 
 For contributors, make sure you also consult the following:
 - [Code of conduct](docs/code-of-conduct.md)

--- a/distbench_busybox.cc
+++ b/distbench_busybox.cc
@@ -12,40 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "distbench_node_manager.h"
-#include "distbench_test_sequencer.h"
-
 #include <fcntl.h>
 
 #include <fstream>
 
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
+#include "distbench_node_manager.h"
+#include "distbench_test_sequencer.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "google/protobuf/text_format.h"
 
 namespace {
 bool AreRemainingArgumentsOK(std::vector<char*> remaining_arguments,
                              size_t min_expected, size_t max_expected);
-int MainRunTests(std::vector<char*> &arguments);
-int MainTestSequencer(std::vector<char*> &arguments);
-int MainNodeManager(std::vector<char*> &arguments);
+int MainRunTests(std::vector<char*>& arguments);
+int MainTestSequencer(std::vector<char*>& arguments);
+int MainNodeManager(std::vector<char*>& arguments);
 void Usage();
 }  // anonymous namespace
 
 ABSL_FLAG(int, port, 10000, "port to listen on");
 ABSL_FLAG(std::string, test_sequencer, "", "host:port of test sequencer");
 ABSL_FLAG(bool, use_ipv4_first, false,
-    "Prefer IPv4 addresses to IPv6 addresses when both are available");
+          "Prefer IPv4 addresses to IPv6 addresses when both are available");
 ABSL_FLAG(bool, binary_output, false, "Save protobufs in binary mode");
 ABSL_FLAG(std::string, infile, "/dev/stdin", "Input file");
 ABSL_FLAG(std::string, outfile, "/dev/stdout", "Output file");
 ABSL_FLAG(int, local_nodes, 0,
-    "The number of node managers to run alongside the test sequencer "
-    "(primarily for debugging locally)");
+          "The number of node managers to run alongside the test sequencer "
+          "(primarily for debugging locally)");
 ABSL_FLAG(std::string, default_data_plane_device, "",
           "Default netdevice to use for the data plane (protocol driver)");
-ABSL_FLAG(absl::Duration, max_test_duration,  absl::Hours(0),
+ABSL_FLAG(absl::Duration, max_test_duration, absl::Hours(0),
           "Maximum time to wait for each test - will default to 1 hour if "
           "not specified by this flag or the test's test_timeout attribute");
 
@@ -54,11 +53,11 @@ int main(int argc, char** argv, char** envp) {
   distbench::InitLibs(argv[0]);
   distbench::set_use_ipv4_first(absl::GetFlag(FLAGS_use_ipv4_first));
 
-  bool args_ok = AreRemainingArgumentsOK(
-      remaining_arguments, 2, std::numeric_limits<size_t>::max());
+  bool args_ok = AreRemainingArgumentsOK(remaining_arguments, 2,
+                                         std::numeric_limits<size_t>::max());
   if (!args_ok) return 1;
 
-  char *distbench_module = remaining_arguments[1];
+  char* distbench_module = remaining_arguments[1];
 
   // Remove argv[0] and distbench_module
   remaining_arguments.erase(remaining_arguments.begin(),
@@ -91,7 +90,7 @@ bool AreRemainingArgumentsOK(std::vector<char*> remaining_arguments,
   }
 
   if (nb_arguments > max_expected) {
-    for (auto it=remaining_arguments.begin() + min_expected;
+    for (auto it = remaining_arguments.begin() + min_expected;
          it < remaining_arguments.end(); it++) {
       std::cerr << "Error: unexpected command line argument: " << *it << "\n";
     }
@@ -104,49 +103,45 @@ bool AreRemainingArgumentsOK(std::vector<char*> remaining_arguments,
 }
 
 absl::Status ParseTestSequenceProtoFromFile(
-    const std::string &filename,
-    distbench::TestSequence *test_sequence) {
-
+    const std::string& filename, distbench::TestSequence* test_sequence) {
   absl::StatusOr<std::string> proto_string =
       distbench::ReadFileToString(filename);
-  if (!proto_string.ok())
-    return proto_string.status();
+  if (!proto_string.ok()) return proto_string.status();
 
   // Attempt to parse, assuming it is binary
-  if (test_sequence->ParseFromString(*proto_string))
-    return absl::OkStatus();
+  if (test_sequence->ParseFromString(*proto_string)) return absl::OkStatus();
 
   // Attempt to parse, assuming it is text
   if (google::protobuf::TextFormat::ParseFromString(*proto_string,
-                                                     test_sequence))
+                                                    test_sequence))
     return absl::OkStatus();
 
   return absl::InvalidArgumentError(
       "Error parsing the TestSequence proto file");
 }
 
-absl::Status SaveResultProtoToFile(const std::string &filename,
-                              const distbench::TestSequenceResults &result) {
+absl::Status SaveResultProtoToFile(
+    const std::string& filename, const distbench::TestSequenceResults& result) {
   int fd_proto = open(filename.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
   if (fd_proto < 0) {
-    std::string error_message{"Error opening the output result proto file for "
-      "writing: "};
+    std::string error_message{
+        "Error opening the output result proto file for "
+        "writing: "};
     return absl::InvalidArgumentError(error_message + filename);
   }
 
   google::protobuf::io::FileOutputStream fos_resultproto(fd_proto);
   if (!google::protobuf::TextFormat::Print(result, &fos_resultproto)) {
-    return absl::InvalidArgumentError(
-        "Error writing the result proto file");
+    return absl::InvalidArgumentError("Error writing the result proto file");
   }
 
   return absl::OkStatus();
 }
 
-absl::Status SaveResultProtoToFileBinary(const std::string &filename,
-                              const distbench::TestSequenceResults &result) {
-  std::fstream output(filename, std::ios::out | std::ios::trunc |
-                                std::ios::binary);
+absl::Status SaveResultProtoToFileBinary(
+    const std::string& filename, const distbench::TestSequenceResults& result) {
+  std::fstream output(filename,
+                      std::ios::out | std::ios::trunc | std::ios::binary);
   if (!result.SerializeToOstream(&output)) {
     return absl::InvalidArgumentError(
         "Error writing the result proto file in binary mode");
@@ -159,11 +154,11 @@ absl::Status SaveResultProtoToFileBinary(const std::string &filename,
 // If even a single test hasn't a test_timeout specified, returns
 // timeout_default
 absl::StatusOr<int64_t> GetTestSequenceTimeout(
-    const distbench::TestSequence &test_sequence, int64_t timeout_default) {
+    const distbench::TestSequence& test_sequence, int64_t timeout_default) {
   int64_t accumulated_timeout = 0;
   for (const auto& test : test_sequence.tests()) {
-    auto maybe_timeout = GetNamedAttributeInt64(test, "test_timeout",
-        std::numeric_limits<int64_t>::min());
+    auto maybe_timeout = GetNamedAttributeInt64(
+        test, "test_timeout", std::numeric_limits<int64_t>::min());
     if (!maybe_timeout.ok()) {
       return maybe_timeout;
     }
@@ -185,7 +180,7 @@ absl::StatusOr<int64_t> GetTestSequenceTimeout(
   return accumulated_timeout;
 }
 
-void SetAllTestTimeoutAttributesTo(distbench::TestSequence *test_sequence,
+void SetAllTestTimeoutAttributesTo(distbench::TestSequence* test_sequence,
                                    std::string value) {
   std::string name = "test_timeout";
   for (auto& test : *test_sequence->mutable_tests()) {
@@ -193,14 +188,13 @@ void SetAllTestTimeoutAttributesTo(distbench::TestSequence *test_sequence,
   }
 }
 
-int MainRunTests(std::vector<char*> &arguments) {
-  if (!AreRemainingArgumentsOK(arguments, 0, 0))
-    return 1;
+int MainRunTests(std::vector<char*>& arguments) {
+  if (!AreRemainingArgumentsOK(arguments, 0, 0)) return 1;
 
   distbench::TestSequence test_sequence;
   const std::string infile = absl::GetFlag(FLAGS_infile);
-  absl::Status parse_status = ParseTestSequenceProtoFromFile(infile,
-                                                             &test_sequence);
+  absl::Status parse_status =
+      ParseTestSequenceProtoFromFile(infile, &test_sequence);
   if (!parse_status.ok()) {
     std::cerr << "Error reading test sequence: " << parse_status << "\n";
     return 1;
@@ -216,8 +210,8 @@ int MainRunTests(std::vector<char*> &arguments) {
     // 1 hour default if unspecified.
     flag_timeout_seconds = 60 * 60;
   }
-  auto maybe_timeout_seconds = GetTestSequenceTimeout(
-      test_sequence, flag_timeout_seconds);
+  auto maybe_timeout_seconds =
+      GetTestSequenceTimeout(test_sequence, flag_timeout_seconds);
   if (!maybe_timeout_seconds.ok()) {
     std::cerr << "Error in the test sequence: "
               << maybe_timeout_seconds.status() << "\n";
@@ -230,7 +224,7 @@ int MainRunTests(std::vector<char*> &arguments) {
       absl::GetFlag(FLAGS_test_sequencer), client_creds,
       distbench::DistbenchCustomChannelArguments());
   std::unique_ptr<distbench::DistBenchTestSequencer::Stub> stub =
-    distbench::DistBenchTestSequencer::NewStub(channel);
+      distbench::DistBenchTestSequencer::NewStub(channel);
 
   if (!stub) {
     std::cerr << "Error connecting to the TestSequencer\n";
@@ -243,11 +237,11 @@ int MainRunTests(std::vector<char*> &arguments) {
       std::chrono::seconds(*maybe_timeout_seconds);
   context.set_deadline(deadline);
   distbench::TestSequenceResults test_results;
-  grpc::Status status = stub->RunTestSequence(&context, test_sequence,
-                                              &test_results);
+  grpc::Status status =
+      stub->RunTestSequence(&context, test_sequence, &test_results);
   if (!status.ok()) {
-    std::cerr << "The RunTestSequence RPC Failed with status: "
-              << status << "\n";
+    std::cerr << "The RunTestSequence RPC Failed with status: " << status
+              << "\n";
     if (status.error_message() == "failed to connect to all addresses") {
       std::cerr << "There may be a problem with the test sequencer running on '"
                 << absl::GetFlag(FLAGS_test_sequencer)
@@ -257,9 +251,9 @@ int MainRunTests(std::vector<char*> &arguments) {
     return 1;
   }
 
-  for (const auto& test_result: test_results.test_results()) {
+  for (const auto& test_result : test_results.test_results()) {
     std::cout << "Test summary:\n";
-    for (const auto& log_summary: test_result.log_summary()) {
+    for (const auto& log_summary : test_result.log_summary()) {
       std::cout << log_summary << "\n";
     }
     std::cout << "\n";
@@ -282,11 +276,11 @@ int MainRunTests(std::vector<char*> &arguments) {
   return 0;
 }
 
-int MainTestSequencer(std::vector<char*> &arguments) {
+int MainTestSequencer(std::vector<char*>& arguments) {
   if (!AreRemainingArgumentsOK(arguments, 0, 0)) return 1;
   int port = absl::GetFlag(FLAGS_port);
   distbench::TestSequencerOpts opts = {
-    .port = &port,
+      .port = &port,
   };
   distbench::TestSequencer test_sequencer;
   test_sequencer.Initialize(opts);
@@ -296,14 +290,14 @@ int MainTestSequencer(std::vector<char*> &arguments) {
   for (int i = 0; i < num_nodes; ++i) {
     int new_port = 0;
     const distbench::NodeManagerOpts opts = {
-      .test_sequencer_service_address = test_sequencer.service_address(),
-      .port = &new_port,
+        .test_sequencer_service_address = test_sequencer.service_address(),
+        .port = &new_port,
     };
     nodes.push_back(std::make_unique<distbench::NodeManager>());
     absl::Status status = nodes.back()->Initialize(opts);
     if (!status.ok()) {
-      std::cerr << "Initializing one of the node managers failed: "
-                << status << std::endl;
+      std::cerr << "Initializing one of the node managers failed: " << status
+                << std::endl;
     }
   }
   test_sequencer.Wait();
@@ -314,19 +308,20 @@ int MainTestSequencer(std::vector<char*> &arguments) {
   return 0;
 }
 
-int MainNodeManager(std::vector<char*> &arguments) {
+int MainNodeManager(std::vector<char*>& arguments) {
   if (!AreRemainingArgumentsOK(arguments, 0, 0)) return 1;
   int port = absl::GetFlag(FLAGS_port);
   const distbench::NodeManagerOpts opts = {
-    .test_sequencer_service_address = absl::GetFlag(FLAGS_test_sequencer),
-    .default_data_plane_device = absl::GetFlag(FLAGS_default_data_plane_device),
-    .port = &port,
+      .test_sequencer_service_address = absl::GetFlag(FLAGS_test_sequencer),
+      .default_data_plane_device =
+          absl::GetFlag(FLAGS_default_data_plane_device),
+      .port = &port,
   };
   distbench::NodeManager node_manager;
   absl::Status status = node_manager.Initialize(opts);
   if (!status.ok()) {
-    std::cerr << "Initializing the node manager failed: "
-              << status << std::endl;
+    std::cerr << "Initializing the node manager failed: " << status
+              << std::endl;
   }
   node_manager.Wait();
   return !status.ok();
@@ -339,22 +334,22 @@ void Usage() {
   std::cerr << "\n";
   std::cerr << "  distbench test_sequencer [--port=port_number]\n";
   std::cerr << "      --port=port_number    The port for the "
-                                 "test_sequencer to listen on.\n";
+               "test_sequencer to listen on.\n";
   std::cerr << "\n";
   std::cerr << "  distbench node_manager [--test_sequencer=host:port] "
-                                        "[--port=port_number]\n";
+               "[--port=port_number]\n";
   std::cerr << "      --test_sequencer=h:p  The host:port of the "
-                          "test_sequencer to connect to.\n";
+               "test_sequencer to connect to.\n";
   std::cerr << "      --port=port_number    The port for the "
-                                 "node_manager to listen on.\n";
+               "node_manager to listen on.\n";
 
   std::cerr << "\n";
   std::cerr << "  distbench run_tests "
-            "--test_sequencer=host:port "
-            "[--infile test_sequence.proto_text] "
-            "[--outfile result.proto_text] "
-            "[--binary_output]"
-            "\n";
+               "--test_sequencer=host:port "
+               "[--infile test_sequence.proto_text] "
+               "[--outfile result.proto_text] "
+               "[--binary_output]"
+               "\n";
   std::cerr << "\n";
   std::cerr << "  distbench help\n";
   std::cerr << "\n";

--- a/distbench_engine.cc
+++ b/distbench_engine.cc
@@ -14,11 +14,11 @@
 
 #include "distbench_engine.h"
 
-#include "distbench_utils.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_split.h"
+#include "distbench_utils.h"
 #include "glog/logging.h"
 
 namespace distbench {
@@ -36,7 +36,7 @@ grpc::Status DistBenchEngine::SetupConnection(grpc::ServerContext* context,
 }
 
 DistBenchEngine::DistBenchEngine(std::unique_ptr<ProtocolDriver> pd)
-  : pd_(std::move(pd)) {
+    : pd_(std::move(pd)) {
   clock_ = &pd_->GetClock();
 }
 
@@ -144,14 +144,13 @@ absl::Status DistBenchEngine::InitializeRpcDefinitionStochastic(
 
   if (total_probability != 1.0) {
     LOG(WARNING) << "The probability for the stochastic fanout of "
-                 << rpc_def.rpc_spec.name()
-                 << " does not add up to 1.0 (is "
+                 << rpc_def.rpc_spec.name() << " does not add up to 1.0 (is "
                  << total_probability << ")";
   }
 
   if (rpc_def.stochastic_dist.empty()) {
-      return absl::InvalidArgumentError(
-          "Invalid stochastic filter; need at least a value pair");
+    return absl::InvalidArgumentError(
+        "Invalid stochastic filter; need at least a value pair");
   }
 
   rpc_def.is_stochastic_fanout = true;
@@ -175,9 +174,8 @@ absl::Status DistBenchEngine::InitializeRpcDefinitionsMap() {
     }
     if (rpc_def.request_payload_size == -1) {
       rpc_def.request_payload_size = 16;
-      LOG(WARNING) << "No request payload defined for " << rpc_name <<
-                 "; using a default of " <<
-                 rpc_def.request_payload_size;
+      LOG(WARNING) << "No request payload defined for " << rpc_name
+                   << "; using a default of " << rpc_def.request_payload_size;
     }
 
     // Get response payload size
@@ -188,14 +186,12 @@ absl::Status DistBenchEngine::InitializeRpcDefinitionsMap() {
     }
     if (rpc_def.response_payload_size == -1) {
       rpc_def.response_payload_size = 32;
-      LOG(WARNING) << "No response payload defined for " << rpc_name <<
-                 "; using a default of " <<
-                 rpc_def.response_payload_size;
+      LOG(WARNING) << "No response payload defined for " << rpc_name
+                   << "; using a default of " << rpc_def.response_payload_size;
     }
 
     auto ret = InitializeRpcDefinitionStochastic(rpc_def);
-    if (!ret.ok())
-      return ret;
+    if (!ret.ok()) return ret;
 
     rpc_map_[rpc_name] = rpc_def;
   }
@@ -217,9 +213,9 @@ absl::Status DistBenchEngine::InitializeTables() {
     action_map[action.name()] = traffic_config_.actions(i);
   }
   std::map<std::string, int> rpc_name_index_map =
-    EnumerateRpcs(traffic_config_);
+      EnumerateRpcs(traffic_config_);
   std::map<std::string, int> service_index_map =
-    EnumerateServiceTypes(traffic_config_);
+      EnumerateServiceTypes(traffic_config_);
 
   std::map<std::string, int> action_list_index_map;
   action_lists_.resize(traffic_config_.action_lists().size());
@@ -256,7 +252,7 @@ absl::Status DistBenchEngine::InitializeTables() {
         }
         action.rpc_index = it2->second;
         std::string target_service_name =
-          traffic_config_.rpc_descriptions(action.rpc_index).server();
+            traffic_config_.rpc_descriptions(action.rpc_index).server();
         auto it3 = service_index_map.find(target_service_name);
         if (it3 == service_index_map.end()) {
           return absl::NotFoundError(target_service_name);
@@ -266,7 +262,7 @@ absl::Status DistBenchEngine::InitializeTables() {
         auto it4 = action_list_index_map.find(action.proto.action_list_name());
         if (it4 == action_list_index_map.end()) {
           return absl::InvalidArgumentError(absl::StrCat(
-                "Action_list not found: ", action.proto.action_list_name()));
+              "Action_list not found: ", action.proto.action_list_name()));
         }
         action.actionlist_index = it4->second;
       } else {
@@ -332,17 +328,15 @@ absl::Status DistBenchEngine::InitializeTables() {
 
     auto it1 = service_index_map.find(server_service_name);
     if (it1 == service_index_map.end()) {
-      return absl::InvalidArgumentError(
-          absl::StrCat(
-            "Rpc ", rpc.name(), " specifies unknown server service_type ",
-            server_service_name));
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Rpc ", rpc.name(), " specifies unknown server service_type ",
+          server_service_name));
     }
     auto it2 = service_index_map.find(client_service_name);
     if (it2 == service_index_map.end()) {
-      return absl::InvalidArgumentError(
-          absl::StrCat(
-            "Rpc ", rpc.name(), " specifies unknown client service_type ",
-            client_service_name));
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Rpc ", rpc.name(), " specifies unknown client service_type ",
+          client_service_name));
     }
     client_rpc_table_[i].service_index = it1->second;
     client_rpc_table_[i].rpc_definition = rpc_map_[rpc.name()];
@@ -371,7 +365,7 @@ absl::Status DistBenchEngine::Initialize(
   grpc::ServerBuilder builder;
   builder.SetMaxReceiveMessageSize(std::numeric_limits<int32_t>::max());
   std::shared_ptr<grpc::ServerCredentials> server_creds =
-    MakeServerCredentials();
+      MakeServerCredentials();
   builder.AddListeningPort(server_address, server_creds, port);
   builder.AddChannelArgument(GRPC_ARG_ALLOW_REUSEPORT, 0);
   builder.RegisterService(this);
@@ -383,8 +377,7 @@ absl::Status DistBenchEngine::Initialize(
   }
   LOG(INFO) << "Engine server listening on " << server_address;
 
-  std::map<std::string, int> services =
-    EnumerateServiceTypes(traffic_config_);
+  std::map<std::string, int> services = EnumerateServiceTypes(traffic_config_);
   auto it = services.find(service_name_);
 
   if (it == services.end()) {
@@ -397,9 +390,7 @@ absl::Status DistBenchEngine::Initialize(
 }
 
 absl::Status DistBenchEngine::ConfigurePeers(const ServiceEndpointMap& peers) {
-  pd_->SetHandler([this](ServerRpcState* state) {
-    return RpcHandler(state);
-  });
+  pd_->SetHandler([this](ServerRpcState* state) { return RpcHandler(state); });
   service_map_ = peers;
   if (service_map_.service_endpoints_size() < 2) {
     return absl::NotFoundError("No peers configured.");
@@ -410,11 +401,11 @@ absl::Status DistBenchEngine::ConfigurePeers(const ServiceEndpointMap& peers) {
 
 absl::Status DistBenchEngine::ConnectToPeers() {
   std::map<std::string, int> service_sizes =
-    EnumerateServiceSizes(traffic_config_);
+      EnumerateServiceSizes(traffic_config_);
   std::map<std::string, int> service_instance_ids =
-    EnumerateServiceInstanceIds(traffic_config_);
+      EnumerateServiceInstanceIds(traffic_config_);
   std::map<std::string, int> service_index_map =
-    EnumerateServiceTypes(traffic_config_);
+      EnumerateServiceTypes(traffic_config_);
 
   // peers_[service_id][instance_id]
   peers_.resize(traffic_config_.services_size());
@@ -429,7 +420,7 @@ absl::Status DistBenchEngine::ConnectToPeers() {
     CHECK(it != service_instance_ids.end());
     int peer_trace_id = it->second;
     std::vector<std::string> service_and_instance =
-      absl::StrSplit(service.first, '/');
+        absl::StrSplit(service.first, '/');
     CHECK_EQ(service_and_instance.size(), 2ul);
     auto& service_type = service_and_instance[0];
     int instance;
@@ -445,7 +436,7 @@ absl::Status DistBenchEngine::ConnectToPeers() {
 
     if (dependent_services_.count(service_type)) {
       peers_[service_id][instance].endpoint_address =
-        service.second.endpoint_address();
+          service.second.endpoint_address();
       peers_[service_id][instance].pd_id = num_targets;
       ++num_targets;
     }
@@ -470,10 +461,10 @@ absl::Status DistBenchEngine::ConnectToPeers() {
       if (!service_instance.endpoint_address.empty()) {
         auto& rpc_state = pending_rpcs[rpc_count];
         std::shared_ptr<grpc::ChannelCredentials> creds =
-          MakeChannelCredentials();
+            MakeChannelCredentials();
         std::shared_ptr<grpc::Channel> channel =
-          grpc::CreateCustomChannel(service_instance.endpoint_address, creds,
-                                    DistbenchCustomChannelArguments());
+            grpc::CreateCustomChannel(service_instance.endpoint_address, creds,
+                                      DistbenchCustomChannelArguments());
         rpc_state.stub = ConnectionSetup::NewStub(channel);
         rpc_state.server_address = service_instance.endpoint_address;
         CHECK(rpc_state.stub);
@@ -481,12 +472,12 @@ absl::Status DistBenchEngine::ConnectToPeers() {
         ++rpc_count;
         rpc_state.request.set_initiator_info(pd_->Preconnect().value());
         std::chrono::system_clock::time_point deadline =
-          std::chrono::system_clock::now() + std::chrono::seconds(60);
+            std::chrono::system_clock::now() + std::chrono::seconds(60);
         rpc_state.context.set_deadline(deadline);
         rpc_state.rpc = rpc_state.stub->AsyncSetupConnection(
             &rpc_state.context, rpc_state.request, &cq);
-        rpc_state.rpc->Finish(
-            &rpc_state.response, &rpc_state.status, &rpc_state);
+        rpc_state.rpc->Finish(&rpc_state.response, &rpc_state.status,
+                              &rpc_state);
       }
     }
   }
@@ -496,14 +487,14 @@ absl::Status DistBenchEngine::ConnectToPeers() {
     cq.Next(&tag, &ok);
     if (ok) {
       --rpc_count;
-      PendingRpc *finished_rpc = static_cast<PendingRpc*>(tag);
+      PendingRpc* finished_rpc = static_cast<PendingRpc*>(tag);
       if (!finished_rpc->status.ok()) {
         pd_->HandleConnectFailure(finished_rpc->request.initiator_info());
         status = finished_rpc->status;
         LOG(ERROR) << "ConnectToPeers error:"
-                   << finished_rpc->status.error_code()
-                   << " " << finished_rpc->status.error_message()
-                   << " connecting to " << finished_rpc->server_address;
+                   << finished_rpc->status.error_code() << " "
+                   << finished_rpc->status.error_message() << " connecting to "
+                   << finished_rpc->server_address;
       }
     }
   }
@@ -536,9 +527,8 @@ absl::Status DistBenchEngine::RunTraffic(const RunTrafficRequest* request) {
         delete top_level_state;
       });
       engine_main_thread_ = RunRegisteredThread(
-          "EngineMain", [this, i, top_level_state]() {
-            RunActionList(i, top_level_state);}
-          );
+          "EngineMain",
+          [this, i, top_level_state]() { RunActionList(i, top_level_state); });
       break;
     }
   }
@@ -570,7 +560,8 @@ ServicePerformanceLog DistBenchEngine::GetLogs() {
           int32_t rpc_index = map_pair.first;
           const RpcPerformanceLog& rpc_perf_log = map_pair.second;
           if (rpc_perf_log.successful_rpc_samples().empty() &&
-              rpc_perf_log.failed_rpc_samples().empty()) continue;
+              rpc_perf_log.failed_rpc_samples().empty())
+            continue;
           auto& output_peer_log =
               (*log.mutable_peer_logs())[peers_[i][j].log_name];
           auto& output_rpc_logs = *output_peer_log.mutable_rpc_logs();
@@ -588,7 +579,7 @@ ServicePerformanceLog DistBenchEngine::GetLogs() {
 // if have_dedicated_thread == false, only short RPCs are performed inline,
 // and longer RPCs will return a non-empty function that the protocol driver
 // should process in a seperate thread.
-std::function<void ()> DistBenchEngine::RpcHandler(ServerRpcState* state) {
+std::function<void()> DistBenchEngine::RpcHandler(ServerRpcState* state) {
   // LOG(INFO) << state->request->ShortDebugString();
   CHECK(state->request->has_rpc_index());
   const auto& server_rpc = server_rpc_table_[state->request->rpc_index()];
@@ -599,12 +590,12 @@ std::function<void ()> DistBenchEngine::RpcHandler(ServerRpcState* state) {
   if (handler_action_list_index == -1) {
     state->SendResponseIfSet();
     state->FreeStateIfSet();
-    return std::function<void ()>();
+    return std::function<void()>();
   }
 
   if (state->have_dedicated_thread) {
     RunActionList(handler_action_list_index, state);
-    return std::function<void ()>();
+    return std::function<void()>();
   }
 
   ++detached_actionlist_threads_;
@@ -614,9 +605,9 @@ std::function<void ()> DistBenchEngine::RpcHandler(ServerRpcState* state) {
   };
 }
 
-void DistBenchEngine::RunActionList(
-    int list_index, const ServerRpcState* incoming_rpc_state,
-    bool force_warmup) {
+void DistBenchEngine::RunActionList(int list_index,
+                                    const ServerRpcState* incoming_rpc_state,
+                                    bool force_warmup) {
   CHECK_LT(static_cast<size_t>(list_index), action_lists_.size());
   CHECK_GE(list_index, 0);
   ActionListState s = {};
@@ -672,7 +663,7 @@ void DistBenchEngine::RunActionList(
           s.FinishAction(i);
         };
       } else {
-        s.state_table[i].all_done_callback = [&s, i]() {s.FinishAction(i);};
+        s.state_table[i].all_done_callback = [&s, i]() { s.FinishAction(i); };
       }
       s.state_table[i].action_list_state = &s;
       RunAction(&s.state_table[i]);
@@ -694,15 +685,15 @@ void DistBenchEngine::RunActionList(
     };
 
     if (clock_->MutexLockWhenWithDeadline(
-          &s.action_mu,
-          absl::Condition(&some_actions_finished), next_iteration_time)) {
+            &s.action_mu, absl::Condition(&some_actions_finished),
+            next_iteration_time)) {
       if (s.finished_action_indices.empty()) {
         LOG(FATAL) << "finished_action_indices is empty";
       }
       for (const auto& finished_action_index : s.finished_action_indices) {
         s.state_table[finished_action_index].finished = true;
         s.state_table[finished_action_index].next_iteration_time =
-          absl::InfiniteFuture();
+            absl::InfiniteFuture();
       }
       s.finished_action_indices.clear();
     }
@@ -741,7 +732,9 @@ void DistBenchEngine::ActionListState::FinishAction(int action_index) {
 }
 
 void DistBenchEngine::ActionListState::WaitForAllPendingActions() {
-  auto some_actions_finished = [&]() {return !finished_action_indices.empty();};
+  auto some_actions_finished = [&]() {
+    return !finished_action_indices.empty();
+  };
   bool done;
   do {
     action_mu.LockWhen(absl::Condition(&some_actions_finished));
@@ -793,9 +786,10 @@ void DistBenchEngine::ActionListState::UnpackLatencySamples() {
   }
 }
 
-void DistBenchEngine::ActionListState::RecordLatency(
-    size_t rpc_index, size_t service_type, size_t instance,
-    ClientRpcState* state) {
+void DistBenchEngine::ActionListState::RecordLatency(size_t rpc_index,
+                                                     size_t service_type,
+                                                     size_t instance,
+                                                     ClientRpcState* state) {
   // If we are using packed samples we avoid grabbing a mutex, but are limited
   // in how many samples total we can collect:
   if (packed_samples_size_) {
@@ -803,10 +797,10 @@ void DistBenchEngine::ActionListState::RecordLatency(
         &packed_sample_number_, 1UL, std::memory_order_relaxed);
     size_t index = sample_number;
     if (index < packed_samples_size_) {
-      RecordPackedLatency(
-          sample_number, index, rpc_index, service_type, instance, state);
-      atomic_fetch_sub_explicit(
-          &remaining_initial_samples_, 1UL, std::memory_order_release);
+      RecordPackedLatency(sample_number, index, rpc_index, service_type,
+                          instance, state);
+      atomic_fetch_sub_explicit(&remaining_initial_samples_, 1UL,
+                                std::memory_order_release);
       return;
     }
     // Simple Reservoir Sampling:
@@ -823,16 +817,17 @@ void DistBenchEngine::ActionListState::RecordLatency(
       return;
     }
     // Wait until all initial samples are done:
-    while (atomic_load_explicit(
-          &remaining_initial_samples_, std::memory_order_acquire)) {}
+    while (atomic_load_explicit(&remaining_initial_samples_,
+                                std::memory_order_acquire)) {
+    }
     // Reservoir samples are serialized.
     absl::MutexLock m(&reservoir_sample_lock_);
     PackedLatencySample& packed_sample = packed_samples_[index];
     if (packed_sample.sample_number < sample_number) {
       // Without arena allocation, via sample_arena_ we would need to do:
       // delete packed_sample.trace_context;
-      RecordPackedLatency(
-          sample_number, index, rpc_index, service_type, instance, state);
+      RecordPackedLatency(sample_number, index, rpc_index, service_type,
+                          instance, state);
     }
     return;
   }
@@ -851,9 +846,9 @@ void DistBenchEngine::ActionListState::RecordLatency(
   auto latency = state->end_time - state->start_time;
   sample->set_start_timestamp_ns(absl::ToUnixNanos(state->start_time));
   sample->set_latency_ns(absl::ToInt64Nanoseconds(latency));
-  if (state->prior_start_time  != absl::InfinitePast()) {
-    sample->set_latency_weight(absl::ToInt64Nanoseconds(
-          state->start_time - state->prior_start_time));
+  if (state->prior_start_time != absl::InfinitePast()) {
+    sample->set_latency_weight(
+        absl::ToInt64Nanoseconds(state->start_time - state->prior_start_time));
   }
   sample->set_request_size(state->request.payload().size());
   sample->set_response_size(state->response.payload().size());
@@ -862,7 +857,7 @@ void DistBenchEngine::ActionListState::RecordLatency(
   }
   if (!state->request.trace_context().engine_ids().empty()) {
     *sample->mutable_trace_context() =
-      std::move(state->request.trace_context());
+        std::move(state->request.trace_context());
   }
 }
 
@@ -881,9 +876,9 @@ void DistBenchEngine::ActionListState::RecordPackedLatency(
   packed_sample.start_timestamp_ns = absl::ToUnixNanos(state->start_time);
   packed_sample.latency_ns = absl::ToInt64Nanoseconds(latency);
   packed_sample.latency_weight = 0;
-  if (state->prior_start_time  != absl::InfinitePast()) {
-    packed_sample.latency_weight = absl::ToInt64Nanoseconds(
-        state->start_time - state->prior_start_time);
+  if (state->prior_start_time != absl::InfinitePast()) {
+    packed_sample.latency_weight =
+        absl::ToInt64Nanoseconds(state->start_time - state->prior_start_time);
   }
   packed_sample.request_size = state->request.payload().size();
   packed_sample.response_size = state->response.payload().size();
@@ -898,28 +893,27 @@ void DistBenchEngine::RunAction(ActionState* action_state) {
   auto& action = *action_state->action;
   if (action.actionlist_index >= 0) {
     std::shared_ptr<const GenericRequest> copied_request =
-      std::make_shared<GenericRequest>(
-          *action_state->action_list_state->incoming_rpc_state->request);
+        std::make_shared<GenericRequest>(
+            *action_state->action_list_state->incoming_rpc_state->request);
     int action_list_index = action.actionlist_index;
     action_state->iteration_function =
-      [this, action_list_index, copied_request]
-      (std::shared_ptr<ActionIterationState>iteration_state) {
-        ServerRpcState *copied_server_rpc_state = new ServerRpcState{};
-        copied_server_rpc_state->request = copied_request.get();
-        copied_server_rpc_state->have_dedicated_thread = true;
-        copied_server_rpc_state->SetFreeStateFunction([=] {
-          delete copied_server_rpc_state;
-        });
-        RunRegisteredThread(
-            "ActionListThread",
-            [this, action_list_index, iteration_state, copied_request,
-            copied_server_rpc_state]()
-            mutable {
-              RunActionList(action_list_index, copied_server_rpc_state,
-                            iteration_state->warmup);
-              FinishIteration(iteration_state);
-            }).detach();
-      };
+        [this, action_list_index, copied_request](
+            std::shared_ptr<ActionIterationState> iteration_state) {
+          ServerRpcState* copied_server_rpc_state = new ServerRpcState{};
+          copied_server_rpc_state->request = copied_request.get();
+          copied_server_rpc_state->have_dedicated_thread = true;
+          copied_server_rpc_state->SetFreeStateFunction(
+              [=] { delete copied_server_rpc_state; });
+          RunRegisteredThread(
+              "ActionListThread",
+              [this, action_list_index, iteration_state, copied_request,
+               copied_server_rpc_state]() mutable {
+                RunActionList(action_list_index, copied_server_rpc_state,
+                              iteration_state->warmup);
+                FinishIteration(iteration_state);
+              })
+              .detach();
+        };
   } else if (action.rpc_service_index >= 0) {
     CHECK_LT(static_cast<size_t>(action.rpc_service_index), peers_.size());
     int rpc_service_index = action.rpc_service_index;
@@ -931,9 +925,9 @@ void DistBenchEngine::RunAction(ActionState* action_state) {
     action_state->rpc_index = action.rpc_index;
     action_state->rpc_service_index = rpc_service_index;
     action_state->iteration_function =
-      [this] (std::shared_ptr<ActionIterationState> iteration_state) {
-        RunRpcActionIteration(iteration_state);
-      };
+        [this](std::shared_ptr<ActionIterationState> iteration_state) {
+          RunRpcActionIteration(iteration_state);
+        };
   } else {
     LOG(FATAL) << "Do not support simulated computations yet";
   }
@@ -948,8 +942,9 @@ void DistBenchEngine::RunAction(ActionState* action_state) {
       max_iterations = std::numeric_limits<int64_t>::max();
     }
     if (action.proto.iterations().has_max_duration_us()) {
-      time_limit = clock_->Now() + absl::Microseconds(
-          action.proto.iterations().max_duration_us());
+      time_limit =
+          clock_->Now() +
+          absl::Microseconds(action.proto.iterations().max_duration_us());
     }
     open_loop = action.proto.iterations().has_open_loop_interval_ns();
   }
@@ -967,19 +962,19 @@ void DistBenchEngine::RunAction(ActionState* action_state) {
     absl::Duration period = absl::Nanoseconds(
         action_state->action->proto.iterations().open_loop_interval_ns());
     auto& interval_distribution = action_state->action->proto.iterations()
-        .open_loop_interval_distribution();
+                                      .open_loop_interval_distribution();
     if (interval_distribution == "sync_burst") {
       absl::Duration start = clock_->Now() - absl::UnixEpoch();
       action_state->next_iteration_time =
-        period + absl::UnixEpoch() + absl::Floor(start, period);
+          period + absl::UnixEpoch() + absl::Floor(start, period);
     } else if (interval_distribution == "sync_burst_spread") {
       absl::Duration start = clock_->Now() - absl::UnixEpoch();
       double nb_peers = peers_[action_state->rpc_service_index].size();
       double fraction = service_instance_ / nb_peers;
       LOG(INFO) << "sync_burst_spread burst delay: " << fraction * period;
-      action_state->next_iteration_time =
-        period + absl::UnixEpoch() + absl::Floor(start, period) +
-        fraction * period;
+      action_state->next_iteration_time = period + absl::UnixEpoch() +
+                                          absl::Floor(start, period) +
+                                          fraction * period;
     } else {
       action_state->next_iteration_time = clock_->Now();
       StartOpenLoopIteration(action_state);
@@ -1018,7 +1013,7 @@ void DistBenchEngine::FinishIteration(
     std::shared_ptr<ActionIterationState> iteration_state) {
   ActionState* state = iteration_state->action_state;
   bool open_loop =
-    state->action->proto.iterations().has_open_loop_interval_ns();
+      state->action->proto.iterations().has_open_loop_interval_ns();
   bool start_another_iteration = !open_loop;
   bool done = false;
   state->iteration_mutex.Lock();
@@ -1056,9 +1051,10 @@ void DistBenchEngine::FinishIteration(
 void DistBenchEngine::StartIteration(
     std::shared_ptr<ActionIterationState> iteration_state) {
   struct ActionState* action_state = iteration_state->action_state;
-  iteration_state->warmup = action_state->action_list_state->warmup_ ||
-    (iteration_state->iteration_number <
-     action_state->action->proto.iterations().warmup_iterations());
+  iteration_state->warmup =
+      action_state->action_list_state->warmup_ ||
+      (iteration_state->iteration_number <
+       action_state->action->proto.iterations().warmup_iterations());
   action_state->iteration_function(iteration_state);
 }
 
@@ -1114,17 +1110,18 @@ void DistBenchEngine::RunRpcActionIteration(
     }  // End of MutexLock m
     rpc_state->prior_start_time = rpc_state->start_time;
     rpc_state->start_time = clock_->Now();
-    pd_->InitiateRpc(servers[peer_instance].pd_id, rpc_state,
+    pd_->InitiateRpc(
+        servers[peer_instance].pd_id, rpc_state,
         [this, rpc_state, iteration_state, peer_instance]() mutable {
-        ActionState* action_state = iteration_state->action_state;
-        rpc_state->end_time = clock_->Now();
-        action_state->action_list_state->RecordLatency(
-            action_state->rpc_index, action_state->rpc_service_index,
-            peer_instance, rpc_state);
-        if (--iteration_state->remaining_rpcs == 0) {
-          FinishIteration(iteration_state);
-        }
-      });
+          ActionState* action_state = iteration_state->action_state;
+          rpc_state->end_time = clock_->Now();
+          action_state->action_list_state->RecordLatency(
+              action_state->rpc_index, action_state->rpc_service_index,
+              peer_instance, rpc_state);
+          if (--iteration_state->remaining_rpcs == 0) {
+            FinishIteration(iteration_state);
+          }
+        });
   }
 }
 
@@ -1146,7 +1143,7 @@ std::vector<int> DistBenchEngine::PickRpcFanoutTargets(
     int nb_targets = 0;
     float random_val = absl::Uniform(random_generator, 0, 1.0);
     float cur_val = 0.0;
-    for (const auto &d : rpc_def.stochastic_dist) {
+    for (const auto& d : rpc_def.stochastic_dist) {
       cur_val += d.probability;
       if (random_val <= cur_val) {
         nb_targets = d.nb_targets;

--- a/distbench_engine.h
+++ b/distbench_engine.h
@@ -17,10 +17,10 @@
 
 #include <unordered_set>
 
+#include "absl/random/random.h"
 #include "distbench.grpc.pb.h"
 #include "distbench_utils.h"
 #include "protocol_driver.h"
-#include "absl/random/random.h"
 
 namespace distbench {
 
@@ -31,9 +31,7 @@ class DistBenchEngine : public ConnectionSetup::Service {
 
   absl::Status Initialize(
       const DistributedSystemDescription& global_description,
-      std::string_view service_name,
-      int service_instance,
-      int* port);
+      std::string_view service_name, int service_instance, int* port);
 
   absl::Status ConfigurePeers(const ServiceEndpointMap& peers);
   absl::Status RunTraffic(const RunTrafficRequest* request);
@@ -47,7 +45,7 @@ class DistBenchEngine : public ConnectionSetup::Service {
                                ConnectResponse* response) override;
 
  private:
-  struct StochasticDist{
+  struct StochasticDist {
     float probability;
     int nb_targets;
   };
@@ -142,7 +140,7 @@ class DistBenchEngine : public ConnectionSetup::Service {
     int rpc_service_index;
 
     std::function<void(std::shared_ptr<ActionIterationState> iteration_state)>
-      iteration_function;
+        iteration_function;
     std::function<void(void)> all_done_callback;
 
     std::map<int, std::vector<int>> partially_randomized_vectors;
@@ -176,18 +174,11 @@ class DistBenchEngine : public ConnectionSetup::Service {
   struct ActionListState {
     void FinishAction(int action_index);
     void WaitForAllPendingActions();
-    void RecordLatency(
-        size_t rpc_index,
-        size_t service_type,
-        size_t instance,
-        ClientRpcState* state);
-    void RecordPackedLatency(
-        size_t sample_number,
-        size_t index,
-        size_t rpc_index,
-        size_t service_type,
-        size_t instance,
-        ClientRpcState* state);
+    void RecordLatency(size_t rpc_index, size_t service_type, size_t instance,
+                       ClientRpcState* state);
+    void RecordPackedLatency(size_t sample_number, size_t index,
+                             size_t rpc_index, size_t service_type,
+                             size_t instance, ClientRpcState* state);
     void UnpackLatencySamples();
 
     const ServerRpcState* incoming_rpc_state = nullptr;
@@ -197,7 +188,7 @@ class DistBenchEngine : public ConnectionSetup::Service {
     std::vector<int> finished_action_indices;
 
     std::vector<std::vector<PeerPerformanceLog>> peer_logs_
-      ABSL_GUARDED_BY(action_mu);
+        ABSL_GUARDED_BY(action_mu);
     std::unique_ptr<PackedLatencySample[]> packed_samples_;
     size_t packed_samples_size_ = 0;
     std::atomic<size_t> packed_sample_number_ = 0;
@@ -214,8 +205,7 @@ class DistBenchEngine : public ConnectionSetup::Service {
 
   absl::Status InitializeTables();
   absl::Status InitializePayloadsMap();
-  absl::Status InitializeRpcDefinitionStochastic(
-      RpcDefinition& rpc_def);
+  absl::Status InitializeRpcDefinitionStochastic(RpcDefinition& rpc_def);
   absl::Status InitializeRpcDefinitionsMap();
 
   void RunActionList(int list_index, const ServerRpcState* incoming_rpc_state,
@@ -234,7 +224,7 @@ class DistBenchEngine : public ConnectionSetup::Service {
   std::vector<ActionListTableEntry> action_lists_;
 
   absl::Status ConnectToPeers();
-  std::function<void ()> RpcHandler(ServerRpcState* state);
+  std::function<void()> RpcHandler(ServerRpcState* state);
 
   int get_payload_size(const std::string& name);
 

--- a/distbench_engine_test.cc
+++ b/distbench_engine_test.cc
@@ -15,9 +15,9 @@
 #include "distbench_engine.h"
 
 #include "distbench_utils.h"
-#include "protocol_driver_allocator.h"
 #include "gtest/gtest.h"
 #include "gtest_utils.h"
+#include "protocol_driver_allocator.h"
 
 namespace distbench {
 

--- a/distbench_netutils.cc
+++ b/distbench_netutils.cc
@@ -12,53 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _GNU_SOURCE     /* Pre-defined on GNU/Linux */
-#define _GNU_SOURCE     /* To get defns of NI_MAXSERV and NI_MAXHOST */
+#ifndef _GNU_SOURCE /* Pre-defined on GNU/Linux */
+#define _GNU_SOURCE /* To get defns of NI_MAXSERV and NI_MAXHOST */
 #endif
 
 #include "distbench_netutils.h"
 
 #include <arpa/inet.h>
-#include <sys/socket.h>
-#include <netdb.h>
 #include <ifaddrs.h>
+#include <linux/if_link.h>
+#include <netdb.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
-#include <linux/if_link.h>
 #include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #include <string>
 #include <vector>
 
-#include "glog/logging.h"
 #include "absl/strings/match.h"
+#include "glog/logging.h"
 
 namespace distbench {
 
 std::vector<DeviceIpAddress> GetAllAddresses() {
-  struct ifaddrs *ifaddr;
+  struct ifaddrs* ifaddr;
   int family;
   char host[NI_MAXHOST];
   std::vector<DeviceIpAddress> result;
 
-  if (getifaddrs(&ifaddr) == -1)
-    return result;
+  if (getifaddrs(&ifaddr) == -1) return result;
 
   /* Walk through linked list, maintaining head pointer so we
      can free list later */
-  for (struct ifaddrs *ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
-    if (ifa->ifa_addr == NULL)
-      continue;
+  for (struct ifaddrs* ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == NULL) continue;
 
     family = ifa->ifa_addr->sa_family;
-    if (family == AF_PACKET)
-      continue;
+    if (family == AF_PACKET) continue;
 
     int s;
     s = getnameinfo(ifa->ifa_addr,
-                    (family == AF_INET) ? sizeof(struct sockaddr_in) :
-                                          sizeof(struct sockaddr_in6),
+                    (family == AF_INET) ? sizeof(struct sockaddr_in)
+                                        : sizeof(struct sockaddr_in6),
                     host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
     if (s == 0) {  // Success
       DeviceIpAddress ip_address(host, ifa->ifa_name, family);
@@ -70,14 +67,13 @@ std::vector<DeviceIpAddress> GetAllAddresses() {
   return result;
 }
 
-absl::StatusOr<DeviceIpAddress> GetBestAddress(
-    bool prefer_ipv4, std::string_view netdev) {
+absl::StatusOr<DeviceIpAddress> GetBestAddress(bool prefer_ipv4,
+                                               std::string_view netdev) {
   auto all_addresses = GetAllAddresses();
 
   // Exact match
   for (const auto& address : all_addresses) {
-    if (address.isIPv4() == prefer_ipv4 &&
-        address.netdevice() == netdev) {
+    if (address.isIPv4() == prefer_ipv4 && address.netdevice() == netdev) {
       return address;
     }
   }
@@ -92,9 +88,9 @@ absl::StatusOr<DeviceIpAddress> GetBestAddress(
   }
 
   if (!netdev.empty()) {
-    return absl::NotFoundError(absl::StrCat(
-          "No address found for netdev '", netdev,
-          "' (prefer_ipv4=", prefer_ipv4, ")"));
+    return absl::NotFoundError(
+        absl::StrCat("No address found for netdev '", netdev,
+                     "' (prefer_ipv4=", prefer_ipv4, ")"));
   }
 
   int score = 0;
@@ -119,20 +115,16 @@ absl::StatusOr<DeviceIpAddress> GetBestAddress(
 
   if (score == 0) {
     return absl::NotFoundError(absl::StrCat(
-          "No address found for any netdev (prefer_ipv4=", prefer_ipv4, ")"));
+        "No address found for any netdev (prefer_ipv4=", prefer_ipv4, ")"));
   }
 
-  LOG(WARNING) << "Using " << best_match.ToString()
-               << " for netdev " << netdev
-               << " (score=" << score
-               << ", prefer_ipv4=" << prefer_ipv4 << ")";
+  LOG(WARNING) << "Using " << best_match.ToString() << " for netdev " << netdev
+               << " (score=" << score << ", prefer_ipv4=" << prefer_ipv4 << ")";
 
   return best_match;
 }
 
-bool DeviceIpAddress::isIPv4() const {
-  return net_family_ == AF_INET;
-}
+bool DeviceIpAddress::isIPv4() const { return net_family_ == AF_INET; }
 
 std::string DeviceIpAddress::ToString() const {
   std::string ret = ip_ + " on " + device_ + " ";

--- a/distbench_netutils.h
+++ b/distbench_netutils.h
@@ -30,7 +30,7 @@ class DeviceIpAddress {
 
  public:
   DeviceIpAddress() {}
-  DeviceIpAddress(const char *host, const char *devname, int family) {
+  DeviceIpAddress(const char* host, const char* devname, int family) {
     ip_ = std::string(host);
     device_ = std::string(devname);
     net_family_ = family;
@@ -38,17 +38,13 @@ class DeviceIpAddress {
 
   bool isIPv4() const;
   std::string ToString() const;
-  std::string netdevice() const {
-    return device_;
-  }
-  std::string ip() const {
-    return ip_;
-  }
+  std::string netdevice() const { return device_; }
+  std::string ip() const { return ip_; }
 };
 
 std::vector<DeviceIpAddress> GetAllAddresses();
-absl::StatusOr<DeviceIpAddress> GetBestAddress(
-    bool prefer_ipv4, std::string_view netdev);
+absl::StatusOr<DeviceIpAddress> GetBestAddress(bool prefer_ipv4,
+                                               std::string_view netdev);
 
 };  // namespace distbench
 

--- a/distbench_node_manager.h
+++ b/distbench_node_manager.h
@@ -15,9 +15,9 @@
 #ifndef DISTBENCH_DISTBENCH_NODE_MANAGER_H_
 #define DISTBENCH_DISTBENCH_NODE_MANAGER_H_
 
+#include "absl/status/statusor.h"
 #include "distbench.grpc.pb.h"
 #include "distbench_engine.h"
-#include "absl/status/statusor.h"
 
 namespace distbench {
 
@@ -62,7 +62,6 @@ class NodeManager final : public DistBenchNodeManager::Service {
                             const ShutdownNodeRequest* request,
                             ShutdownNodeResult* response) override;
 
-
  private:
   void ClearServices() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
@@ -79,14 +78,14 @@ class NodeManager final : public DistBenchNodeManager::Service {
       const ServiceOpts& service_opts) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   absl::Status AllocService(const ServiceOpts& service_opts)
-    ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   absl::Mutex mutex_;
   DistributedSystemDescription traffic_config_ ABSL_GUARDED_BY(mutex_);
   ServiceEndpointMap peers_ ABSL_GUARDED_BY(mutex_);
 
   std::map<std::string, std::unique_ptr<DistBenchEngine>> service_engines_
-    ABSL_GUARDED_BY(mutex_);
+      ABSL_GUARDED_BY(mutex_);
 
   std::unique_ptr<grpc::Server> grpc_server_;
   std::string service_address_;

--- a/distbench_node_manager_test.cc
+++ b/distbench_node_manager_test.cc
@@ -15,15 +15,13 @@
 #include "distbench_node_manager.h"
 
 #include "distbench_utils.h"
-#include "protocol_driver_allocator.h"
 #include "gtest/gtest.h"
 #include "gtest_utils.h"
+#include "protocol_driver_allocator.h"
 
 namespace distbench {
 
-TEST(DistBenchNodeManager, Constructor) {
-  NodeManager nm;
-}
+TEST(DistBenchNodeManager, Constructor) { NodeManager nm; }
 
 TEST(DistBenchNodeManager, FailNoTestSequencer) {
   NodeManager nm;

--- a/distbench_summary.cc
+++ b/distbench_summary.cc
@@ -14,9 +14,9 @@
 
 #include "distbench_summary.h"
 
-#include "absl/strings/str_split.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#include "absl/strings/str_split.h"
 #include "glog/logging.h"
 
 namespace distbench {
@@ -26,7 +26,7 @@ namespace {
 std::string LatencySummary(std::vector<int64_t> latencies) {
   std::string ret;
 
-  size_t N =  latencies.size();
+  size_t N = latencies.size();
   absl::StrAppendFormat(&ret, "N: %ld", N);
 
   if (N > 0) {
@@ -54,8 +54,8 @@ struct instance_summary {
   int64_t rx_payload_bytes = 0;
 };
 
-void AddCommunicationSummaryTo(std::vector<std::string> &ret,
-    double total_time_seconds,
+void AddCommunicationSummaryTo(
+    std::vector<std::string>& ret, double total_time_seconds,
     std::map<t_string_pair, rpc_traffic_summary> perf_map) {
   ret.push_back("Communication summary:");
   constexpr double MiB = 1024 * 1024;
@@ -63,7 +63,8 @@ void AddCommunicationSummaryTo(std::vector<std::string> &ret,
     std::string name = perf_r.first.first + " -> " + perf_r.first.second;
     auto& perf = perf_r.second;
     std::string str{};
-    absl::StrAppendFormat(&str,
+    absl::StrAppendFormat(
+        &str,
         "  %s: RPCs: %d (%3.2f kQPS) "
         "Request: %3.1f MiB/s Response: %3.1f MiB/s",
         name, perf.nb_rpcs, (double)perf.nb_rpcs / total_time_seconds / 1000.,
@@ -73,8 +74,8 @@ void AddCommunicationSummaryTo(std::vector<std::string> &ret,
   }
 }
 
-void AddInstanceSummaryTo(std::vector<std::string> &ret,
-    double total_time_seconds,
+void AddInstanceSummaryTo(
+    std::vector<std::string>& ret, double total_time_seconds,
     std::map<t_string_pair, rpc_traffic_summary> perf_map) {
   std::map<std::string, instance_summary> instance_summary_map;
   int64_t total_rpcs = 0;
@@ -82,7 +83,7 @@ void AddInstanceSummaryTo(std::vector<std::string> &ret,
   for (auto& perf_r : perf_map) {
     std::string initiator_name = perf_r.first.first;
     std::string target_name = perf_r.first.second;
-    auto &perf = perf_r.second;
+    auto& perf = perf_r.second;
     instance_summary inst_summary{};
     total_rpcs += perf.nb_rpcs;
     total_tx_bytes += perf.request_size + perf.response_size;
@@ -112,8 +113,8 @@ void AddInstanceSummaryTo(std::vector<std::string> &ret,
   for (auto& instance_sum : instance_summary_map) {
     instance_summary inst_summary = instance_sum.second;
     std::string str{};
-    absl::StrAppendFormat(&str, "  %s: Tx: %3.1f MiB/s, Rx:%3.1f MiB/s",
-        instance_sum.first,
+    absl::StrAppendFormat(
+        &str, "  %s: Tx: %3.1f MiB/s, Rx:%3.1f MiB/s", instance_sum.first,
         (double)inst_summary.tx_payload_bytes / MiB / total_time_seconds,
         (double)inst_summary.rx_payload_bytes / MiB / total_time_seconds);
     ret.push_back(str);
@@ -125,11 +126,10 @@ void AddInstanceSummaryTo(std::vector<std::string> &ret,
   ret.push_back(str);
   str = "";
   absl::StrAppendFormat(&str, "  Total Tx: %d MiB (%3.1f MiB/s), ",
-      total_tx_bytes / MiB,
-      (double)total_tx_bytes / MiB / total_time_seconds);
-  absl::StrAppendFormat(&str,
-      "Total Nb RPCs: %d (%3.2f kQPS)",
-      total_rpcs, (double)total_rpcs / 1000 / total_time_seconds);
+                        total_tx_bytes / MiB,
+                        (double)total_tx_bytes / MiB / total_time_seconds);
+  absl::StrAppendFormat(&str, "Total Nb RPCs: %d (%3.2f kQPS)", total_rpcs,
+                        (double)total_rpcs / 1000 / total_time_seconds);
   ret.push_back(str);
 }
 
@@ -148,8 +148,8 @@ std::vector<std::string> SummarizeTestResult(const TestResult& test_result) {
       int64_t end_timestamp_ns = std::numeric_limits<int64_t>::min();
       rpc_traffic_summary perf_record{};
       for (const auto& rpc_log : peer_log.second.rpc_logs()) {
-        std::string rpc_name  =
-          test_result.traffic_config().rpc_descriptions(rpc_log.first).name();
+        std::string rpc_name =
+            test_result.traffic_config().rpc_descriptions(rpc_log.first).name();
         std::vector<int64_t>& latencies = latency_map[rpc_name];
         perf_record.nb_rpcs += rpc_log.second.successful_rpc_samples().size();
         for (const auto& sample : rpc_log.second.successful_rpc_samples()) {
@@ -158,8 +158,8 @@ std::vector<std::string> SummarizeTestResult(const TestResult& test_result) {
           int64_t rpc_request_size = sample.request_size();
           int64_t rpc_response_size = sample.response_size();
 
-          start_timestamp_ns = std::min(rpc_start_timestamp_ns,
-                                        start_timestamp_ns);
+          start_timestamp_ns =
+              std::min(rpc_start_timestamp_ns, start_timestamp_ns);
           end_timestamp_ns = std::max(rpc_start_timestamp_ns + rpc_latency_ns,
                                       end_timestamp_ns);
           perf_record.request_size += rpc_request_size;
@@ -168,8 +168,7 @@ std::vector<std::string> SummarizeTestResult(const TestResult& test_result) {
         }
       }
       if (start_timestamp_ns != std::numeric_limits<int64_t>::max()) {
-        test_time = std::max(test_time,
-                             end_timestamp_ns - start_timestamp_ns);
+        test_time = std::max(test_time, end_timestamp_ns - start_timestamp_ns);
       }
       t_string_pair key_traffic_sum =
           std::make_pair(initiator_instance_name, target_instance_name);
@@ -182,8 +181,8 @@ std::vector<std::string> SummarizeTestResult(const TestResult& test_result) {
   for (auto& latencies : latency_map) {
     std::string str{};
     std::sort(latencies.second.begin(), latencies.second.end());
-    absl::StrAppendFormat(
-        &str, "  %s: %s", latencies.first, LatencySummary(latencies.second));
+    absl::StrAppendFormat(&str, "  %s: %s", latencies.first,
+                          LatencySummary(latencies.second));
     ret.push_back(str);
   }
 

--- a/distbench_test_sequencer.h
+++ b/distbench_test_sequencer.h
@@ -17,9 +17,9 @@
 
 #include <set>
 
-#include "distbench.grpc.pb.h"
 #include "absl/status/statusor.h"
 #include "absl/synchronization/notification.h"
+#include "distbench.grpc.pb.h"
 
 namespace distbench {
 
@@ -57,12 +57,10 @@ class TestSequencer final : public DistBenchTestSequencer::Service {
                                  TestSequenceResults* response);
 
   absl::StatusOr<TestResult> DoRunTest(
-      grpc::ServerContext* context,
-      const DistributedSystemDescription& test);
+      grpc::ServerContext* context, const DistributedSystemDescription& test);
 
   absl::StatusOr<std::map<std::string, std::set<std::string>>> PlaceServices(
       const DistributedSystemDescription& test);
-
 
   absl::StatusOr<ServiceEndpointMap> ConfigureNodes(
       const std::map<std::string, std::set<std::string>>& node_service_map,
@@ -82,10 +80,10 @@ class TestSequencer final : public DistBenchTestSequencer::Service {
   std::vector<RegisteredNode> registered_nodes_ ABSL_GUARDED_BY(mutex_);
   std::map<std::string, int> node_alias_id_map_ ABSL_GUARDED_BY(mutex_);
   std::map<std::string, int> node_registration_id_map_ ABSL_GUARDED_BY(mutex_);
-  grpc::ServerContext* running_test_sequence_context_ ABSL_GUARDED_BY(mutex_)
-    = nullptr;
+  grpc::ServerContext* running_test_sequence_context_ ABSL_GUARDED_BY(mutex_) =
+      nullptr;
   std::shared_ptr<absl::Notification> running_test_notification_
-    ABSL_GUARDED_BY(mutex_);
+      ABSL_GUARDED_BY(mutex_);
   std::unique_ptr<grpc::Server> grpc_server_;
   std::string service_address_;
   TestSequencerOpts opts_;

--- a/distbench_test_sequencer_test.cc
+++ b/distbench_test_sequencer_test.cc
@@ -16,11 +16,11 @@
 
 #include "distbench_node_manager.h"
 #include "distbench_utils.h"
-#include "protocol_driver_allocator.h"
-#include "gtest/gtest.h"
-#include "gtest_utils.h"
 #include "glog/logging.h"
 #include "google/protobuf/text_format.h"
+#include "gtest/gtest.h"
+#include "gtest_utils.h"
+#include "protocol_driver_allocator.h"
 
 namespace distbench {
 
@@ -55,25 +55,21 @@ absl::Status DistBenchTester::Initialize(int num_nodes) {
     distbench::NodeManagerOpts nm_opts = {};
     int port = 0;
     nm_opts.port = &port;
-    nm_opts.test_sequencer_service_address =
-      test_sequencer->service_address();
+    nm_opts.test_sequencer_service_address = test_sequencer->service_address();
     nodes[i] = std::make_unique<NodeManager>();
     auto ret = nodes[i]->Initialize(nm_opts);
-    if (!ret.ok())
-      return ret;
+    if (!ret.ok()) return ret;
   }
   std::shared_ptr<grpc::ChannelCredentials> client_creds =
-    MakeChannelCredentials();
-  std::shared_ptr<grpc::Channel> channel = grpc::CreateCustomChannel(
-      test_sequencer->service_address(), client_creds,
-      DistbenchCustomChannelArguments());
+      MakeChannelCredentials();
+  std::shared_ptr<grpc::Channel> channel =
+      grpc::CreateCustomChannel(test_sequencer->service_address(), client_creds,
+                                DistbenchCustomChannelArguments());
   test_sequencer_stub = DistBenchTestSequencer::NewStub(channel);
   return absl::OkStatus();
 }
 
-TEST(DistBenchTestSequencer, Constructor) {
-  TestSequencer test_sequencer;
-}
+TEST(DistBenchTestSequencer, Constructor) { TestSequencer test_sequencer; }
 
 TEST(DistBenchTestSequencer, Initialization) {
   distbench::TestSequencerOpts ts_opts = {};
@@ -122,7 +118,7 @@ TEST(DistBenchTestSequencer, NonEmptyGroup) {
   TestSequenceResults results;
   grpc::ClientContext context;
   std::chrono::system_clock::time_point deadline =
-    std::chrono::system_clock::now() + std::chrono::seconds(70);
+      std::chrono::system_clock::now() + std::chrono::seconds(70);
   context.set_deadline(deadline);
   grpc::Status status = tester.test_sequencer_stub->RunTestSequence(
       &context, test_sequence, &results);
@@ -132,7 +128,7 @@ TEST(DistBenchTestSequencer, NonEmptyGroup) {
   auto& test_results = results.test_results(0);
   ASSERT_EQ(test_results.service_logs().instance_logs_size(), 1);
   const auto& instance_results_it =
-    test_results.service_logs().instance_logs().find("s1/0");
+      test_results.service_logs().instance_logs().find("s1/0");
   ASSERT_NE(instance_results_it,
             test_results.service_logs().instance_logs().end());
   auto s2_0 = instance_results_it->second.peer_logs().find("s2/0");
@@ -187,7 +183,7 @@ void RunIntenseTraffic(const char* protocol) {
 
   TestSequenceResults results;
   std::chrono::system_clock::time_point deadline =
-    std::chrono::system_clock::now() + std::chrono::seconds(200);
+      std::chrono::system_clock::now() + std::chrono::seconds(200);
   grpc::ClientContext context;
   grpc::ClientContext context2;
   grpc::ClientContext context3;
@@ -200,15 +196,15 @@ void RunIntenseTraffic(const char* protocol) {
   ASSERT_OK(status);
 
   iterations->clear_max_iteration_count();
-  status = tester.test_sequencer_stub->RunTestSequence(
-      &context2, test_sequence, &results);
+  status = tester.test_sequencer_stub->RunTestSequence(&context2, test_sequence,
+                                                       &results);
   LOG(INFO) << status.error_message();
   ASSERT_OK(status);
 
   iterations->clear_max_duration_us();
   iterations->set_max_iteration_count(2000);
-  status = tester.test_sequencer_stub->RunTestSequence(
-      &context3, test_sequence, &results);
+  status = tester.test_sequencer_stub->RunTestSequence(&context3, test_sequence,
+                                                       &results);
   LOG(INFO) << status.error_message();
   ASSERT_OK(status);
 }
@@ -251,7 +247,7 @@ TEST(DistBenchTestSequencer, TestReservoirSampling) {
 
   TestSequenceResults results;
   std::chrono::system_clock::time_point deadline =
-    std::chrono::system_clock::now() + std::chrono::seconds(200);
+      std::chrono::system_clock::now() + std::chrono::seconds(200);
   grpc::ClientContext context;
   context.set_deadline(deadline);
   grpc::Status status = tester.test_sequencer_stub->RunTestSequence(
@@ -345,7 +341,7 @@ TEST(DistBenchTestSequencer, TestWarmupSampling) {
 
   TestSequenceResults results;
   std::chrono::system_clock::time_point deadline =
-    std::chrono::system_clock::now() + std::chrono::seconds(200);
+      std::chrono::system_clock::now() + std::chrono::seconds(200);
   grpc::ClientContext context;
   context.set_deadline(deadline);
   grpc::Status status = tester.test_sequencer_stub->RunTestSequence(
@@ -396,9 +392,7 @@ TEST(DistBenchTestSequencer, TestWarmupSampling) {
   }
   EXPECT_EQ(warmup_samples, 1000);
 }
-TEST(DistBenchTestSequencer, 100kGrpc) {
-  RunIntenseTraffic("grpc");
-}
+TEST(DistBenchTestSequencer, 100kGrpc) { RunIntenseTraffic("grpc"); }
 
 TEST(DistBenchTestSequencer, 100kGrpcAsyncCallback) {
   RunIntenseTraffic("grpc_async_callback");
@@ -445,7 +439,7 @@ TEST(DistBenchTestSequencer, CliqueTest) {
   TestSequenceResults results;
   grpc::ClientContext context;
   std::chrono::system_clock::time_point deadline =
-    std::chrono::system_clock::now() + std::chrono::seconds(75);
+      std::chrono::system_clock::now() + std::chrono::seconds(75);
   context.set_deadline(deadline);
   grpc::Status status = tester.test_sequencer_stub->RunTestSequence(
       &context, test_sequence, &results);
@@ -470,7 +464,7 @@ TEST(DistBenchTestSequencer, CliqueTest) {
 
   ASSERT_EQ(test_results.service_logs().instance_logs_size(), 3);
   const auto& instance_results_it =
-    test_results.service_logs().instance_logs().find("clique/0");
+      test_results.service_logs().instance_logs().find("clique/0");
   ASSERT_NE(instance_results_it,
             test_results.service_logs().instance_logs().end());
 }
@@ -522,14 +516,14 @@ tests {
 })";
 
   TestSequence test_sequence;
-  bool parse_result = google::protobuf::TextFormat::ParseFromString(
-      proto, &test_sequence);
+  bool parse_result =
+      google::protobuf::TextFormat::ParseFromString(proto, &test_sequence);
   ASSERT_EQ(parse_result, true);
 
   TestSequenceResults results;
   grpc::ClientContext context;
   std::chrono::system_clock::time_point deadline =
-    std::chrono::system_clock::now() + std::chrono::seconds(75);
+      std::chrono::system_clock::now() + std::chrono::seconds(75);
   context.set_deadline(deadline);
   grpc::Status status = tester.test_sequencer_stub->RunTestSequence(
       &context, test_sequence, &results);
@@ -592,14 +586,14 @@ tests {
     netdev_name: "lo"
   }
 })";
-  bool parse_result = google::protobuf::TextFormat::ParseFromString(
-      proto, &test_sequence);
+  bool parse_result =
+      google::protobuf::TextFormat::ParseFromString(proto, &test_sequence);
   ASSERT_EQ(parse_result, true);
 
   TestSequenceResults results;
   grpc::ClientContext context;
   std::chrono::system_clock::time_point deadline =
-    std::chrono::system_clock::now() + std::chrono::seconds(15);
+      std::chrono::system_clock::now() + std::chrono::seconds(15);
   context.set_deadline(deadline);
   grpc::Status status = tester.test_sequencer_stub->RunTestSequence(
       &context, test_sequence, &results);
@@ -650,14 +644,14 @@ tests {
   }
 })";
   TestSequence test_sequence;
-  bool parse_result = google::protobuf::TextFormat::ParseFromString(
-      proto, &test_sequence);
+  bool parse_result =
+      google::protobuf::TextFormat::ParseFromString(proto, &test_sequence);
   ASSERT_EQ(parse_result, true);
 
   TestSequenceResults results;
   grpc::ClientContext context;
   std::chrono::system_clock::time_point deadline =
-    std::chrono::system_clock::now() + std::chrono::seconds(15);
+      std::chrono::system_clock::now() + std::chrono::seconds(15);
   context.set_deadline(deadline);
   grpc::Status status = tester.test_sequencer_stub->RunTestSequence(
       &context, test_sequence, &results);
@@ -666,11 +660,11 @@ tests {
   auto& test_results = results.test_results(0);
   ASSERT_EQ(test_results.service_logs().instance_logs_size(), 1);
 
-  auto serv_log_it = test_results.service_logs().instance_logs().find(
-      "client/0");
+  auto serv_log_it =
+      test_results.service_logs().instance_logs().find("client/0");
   for (int i = 0; i < 4; i++) {
-    auto peer_log_it = serv_log_it->second.peer_logs().find(
-        absl::StrCat("server/", i));
+    auto peer_log_it =
+        serv_log_it->second.peer_logs().find(absl::StrCat("server/", i));
     auto rpc_log_it = peer_log_it->second.rpc_logs().find(0);
     ASSERT_EQ(rpc_log_it->second.successful_rpc_samples_size(), 256);
   }
@@ -726,14 +720,14 @@ tests {
   }
 })";
   TestSequence test_sequence;
-  bool parse_result = google::protobuf::TextFormat::ParseFromString(
-      proto, &test_sequence);
+  bool parse_result =
+      google::protobuf::TextFormat::ParseFromString(proto, &test_sequence);
   ASSERT_EQ(parse_result, true);
 
   TestSequenceResults results;
   grpc::ClientContext context;
   std::chrono::system_clock::time_point deadline =
-    std::chrono::system_clock::now() + std::chrono::seconds(15);
+      std::chrono::system_clock::now() + std::chrono::seconds(15);
   context.set_deadline(deadline);
   grpc::Status status = tester.test_sequencer_stub->RunTestSequence(
       &context, test_sequence, &results);
@@ -793,14 +787,14 @@ tests {
   }
 })";
   TestSequence test_sequence;
-  bool parse_result = google::protobuf::TextFormat::ParseFromString(
-      proto, &test_sequence);
+  bool parse_result =
+      google::protobuf::TextFormat::ParseFromString(proto, &test_sequence);
   ASSERT_EQ(parse_result, true);
 
   TestSequenceResults results;
   grpc::ClientContext context;
   std::chrono::system_clock::time_point deadline =
-    std::chrono::system_clock::now() + std::chrono::seconds(15);
+      std::chrono::system_clock::now() + std::chrono::seconds(15);
   context.set_deadline(deadline);
   grpc::Status status = tester.test_sequencer_stub->RunTestSequence(
       &context, test_sequence, &results);

--- a/distbench_utils.h
+++ b/distbench_utils.h
@@ -20,15 +20,15 @@
 #include <memory>
 #include <thread>
 
+#include "absl/status/statusor.h"
 #include "distbench.pb.h"
 #include "distbench_netutils.h"
-#include "traffic_config.pb.h"
-#include "absl/status/statusor.h"
 #include "google/protobuf/stubs/status_macros.h"
 #include "grpc_wrapper.h"
+#include "traffic_config.pb.h"
 
-namespace std{
-ostream& operator<< (ostream &out, grpc::Status const& c);
+namespace std {
+ostream& operator<<(ostream& out, grpc::Status const& c);
 };
 
 namespace distbench {
@@ -40,8 +40,8 @@ std::shared_ptr<grpc::ChannelCredentials> MakeChannelCredentials();
 std::shared_ptr<grpc::ServerCredentials> MakeServerCredentials();
 absl::StatusOr<DeviceIpAddress> IpAddressForDevice(std::string_view netdev);
 std::string SocketAddressForIp(DeviceIpAddress ip, int port);
-absl::StatusOr<std::string> SocketAddressForDevice(
-    std::string_view netdev, int port);
+absl::StatusOr<std::string> SocketAddressForDevice(std::string_view netdev,
+                                                   int port);
 std::thread RunRegisteredThread(const std::string& thread_name,
                                 std::function<void()> f);
 
@@ -63,36 +63,34 @@ std::string Hostname();
 
 grpc::Status Annotate(const grpc::Status& status, std::string_view context);
 
-grpc::Status abslStatusToGrpcStatus(const absl::Status &status);
-absl::Status grpcStatusToAbslStatus(const grpc::Status &status);
+grpc::Status abslStatusToGrpcStatus(const absl::Status& status);
+absl::Status grpcStatusToAbslStatus(const grpc::Status& status);
 
-absl::StatusOr<std::string> ReadFileToString(const std::string &filename);
+absl::StatusOr<std::string> ReadFileToString(const std::string& filename);
 
-void ApplyServerSettingsToGrpcBuilder(grpc::ServerBuilder *builder,
-      const ProtocolDriverOptions &pd_opts);
+void ApplyServerSettingsToGrpcBuilder(grpc::ServerBuilder* builder,
+                                      const ProtocolDriverOptions& pd_opts);
 
 // RUsage functions
-RUsage StructRUsageToMessage(const struct rusage &s_rusage);
-RUsage DiffStructRUsageToMessage(const struct rusage &start,
-                                 const struct rusage &end);
+RUsage StructRUsageToMessage(const struct rusage& s_rusage);
+RUsage DiffStructRUsageToMessage(const struct rusage& start,
+                                 const struct rusage& end);
 
-RUsageStats GetRUsageStatsFromStructs(const struct rusage &start,
-                                      const struct rusage &end);
+RUsageStats GetRUsageStatsFromStructs(const struct rusage& start,
+                                      const struct rusage& end);
 struct rusage DoGetRusage();
 
 std::string GetNamedSettingString(
-    const ::google::protobuf::RepeatedPtrField<distbench::NamedSetting>
-    &settings, absl::string_view name, std::string default_value);
+    const ::google::protobuf::RepeatedPtrField<distbench::NamedSetting>&
+        settings,
+    absl::string_view name, std::string default_value);
 
-int64_t GetNamedSettingInt64(
-    const distbench::ProtocolDriverOptions &opts,
-    absl::string_view name,
-    int64_t default_value);
+int64_t GetNamedSettingInt64(const distbench::ProtocolDriverOptions& opts,
+                             absl::string_view name, int64_t default_value);
 
 absl::StatusOr<int64_t> GetNamedAttributeInt64(
-    const distbench::DistributedSystemDescription &test,
-    absl::string_view name, int64_t default_value);
-
+    const distbench::DistributedSystemDescription& test, absl::string_view name,
+    int64_t default_value);
 
 }  // namespace distbench
 

--- a/git_hooks/README.md
+++ b/git_hooks/README.md
@@ -1,0 +1,20 @@
+# Git Hooks
+
+This folder contains client-side hooks that perform:
+- verify that the source code meet the formatting style (using clang-format with
+  the Google style).
+
+## Enable the hooks
+
+The hooks can be enable by running:
+```bash
+git config core.hooksPath git_hooks
+```
+
+## pre-commit
+
+### Code style (clang-format with the Google style)
+
+Currently a pre-commit hook is used to check the formatting style of the .h and
+.cc files. If the test fails, follow the recommendation to resolve the issues.
+

--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+check_all_files() {
+  format_valid=true
+  for file in `git diff-index --cached --name-only HEAD | grep -iE '\.(cc|h)'` ; do
+    if [ -f $file ]; then
+      diff=`clang-format -style=file ${file} | diff -u "$file" -`
+      if [ $? -ne 0 ]; then
+        echo "Invalid clang-format for $file:"
+        echo
+        echo "$diff"
+        echo
+        format_valid=false
+      fi
+    fi
+  done
+
+  if [ $format_valid = false ]; then
+    echo "Commit aborted due to formatting errors. You can:"
+    echo "- Fix the errors, e.g. with make clang-format"
+    echo "- Disable checks on section of the code with:"
+    echo "   // clang-format off"
+    echo "   code"
+    echo "   // clang-format on"
+    echo "- Ignore the issue by using git commit --no-verify (not recommanded)"
+    exit 1
+  fi
+}
+
+case "${1}" in
+ --about )
+   ;;
+ * )
+   check_all_files
+   ;;
+esac
+# Clang Format Hook - End
+

--- a/gtest_utils.h
+++ b/gtest_utils.h
@@ -16,12 +16,13 @@
 #define DISTBENCH_GTEST_UTILS_H_
 
 using ::testing::Test;
-#define ASSERT_OK(s) { \
+#define ASSERT_OK(s)     \
+  {                      \
     auto s_ = (s);       \
     if (!s_.ok()) {      \
-          FAIL() << s_;      \
-          return; /* here */ \
-        }                    \
-}
+      FAIL() << s_;      \
+      return; /* here */ \
+    }                    \
+  }
 
 #endif  // DISTBENCH_GTEST_UTILS_H_

--- a/interface_lookup.cc
+++ b/interface_lookup.cc
@@ -12,46 +12,43 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _GNU_SOURCE     /* Pre-defined on GNU/Linux */
-#define _GNU_SOURCE     /* To get defns of NI_MAXSERV and NI_MAXHOST */
+#ifndef _GNU_SOURCE /* Pre-defined on GNU/Linux */
+#define _GNU_SOURCE /* To get defns of NI_MAXSERV and NI_MAXHOST */
 #endif
 
-#include <arpa/inet.h>
-#include <sys/socket.h>
-#include <netdb.h>
-#include <ifaddrs.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <linux/if_link.h>
-#include <string.h>
 #include "interface_lookup.h"
 
-bool GetFirstAddress(net_base::IPAddress &ip_address, int which_family) {
-  struct ifaddrs *ifaddr;
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <linux/if_link.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+bool GetFirstAddress(net_base::IPAddress& ip_address, int which_family) {
+  struct ifaddrs* ifaddr;
   int family;
   char host[NI_MAXHOST];
 
-  if (getifaddrs(&ifaddr) == -1)
-    return false;
+  if (getifaddrs(&ifaddr) == -1) return false;
 
   /* Walk through linked list, maintaining head pointer so we
      can free list later */
-  for (struct ifaddrs *ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
-    if (ifa->ifa_addr == NULL)
-      continue;
+  for (struct ifaddrs* ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == NULL) continue;
 
     family = ifa->ifa_addr->sa_family;
-    if (family == AF_PACKET)
-      continue;
-    if (strcmp(ifa->ifa_name, "lo") == 0)
-      continue;
+    if (family == AF_PACKET) continue;
+    if (strcmp(ifa->ifa_name, "lo") == 0) continue;
 
     if (family == which_family) {
       int s;
       s = getnameinfo(ifa->ifa_addr,
-                      (family == AF_INET) ? sizeof(struct sockaddr_in) :
-                      sizeof(struct sockaddr_in6),
+                      (family == AF_INET) ? sizeof(struct sockaddr_in)
+                                          : sizeof(struct sockaddr_in6),
                       host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
       if (s != 0) {
         freeifaddrs(ifaddr);
@@ -68,11 +65,10 @@ bool GetFirstAddress(net_base::IPAddress &ip_address, int which_family) {
   return false;
 }
 
-bool net_base::InterfaceLookup::MyIPv4Address(IPAddress *addr) {
+bool net_base::InterfaceLookup::MyIPv4Address(IPAddress* addr) {
   return GetFirstAddress(*addr, AF_INET);
 }
 
-bool net_base::InterfaceLookup::MyIPv6Address(IPAddress *addr) {
+bool net_base::InterfaceLookup::MyIPv6Address(IPAddress* addr) {
   return GetFirstAddress(*addr, AF_INET6);
 }
-

--- a/interface_lookup.h
+++ b/interface_lookup.h
@@ -17,22 +17,22 @@
 
 #include <string>
 
-namespace net_base{
-class IPAddress{
+namespace net_base {
+class IPAddress {
  private:
   std::string address;
 
  public:
-  std::string ToString() const{return this->address;}
-  void from_c_str(const char *s_address) {
+  std::string ToString() const { return this->address; }
+  void from_c_str(const char* s_address) {
     this->address = std::string(s_address);
   }
 };
 
-namespace InterfaceLookup{
+namespace InterfaceLookup {
 
-bool MyIPv4Address(IPAddress *addr);
-bool MyIPv6Address(IPAddress *addr);
+bool MyIPv4Address(IPAddress* addr);
+bool MyIPv6Address(IPAddress* addr);
 
 };  // namespace InterfaceLookup
 };  // namespace net_base

--- a/protocol_driver.cc
+++ b/protocol_driver.cc
@@ -45,9 +45,10 @@ class RealClock : public SimpleClock {
   ~RealClock() override {}
   absl::Time Now() override { return absl::Now(); }
 
-  bool MutexLockWhenWithDeadline(
-      absl::Mutex* mu, const absl::Condition& condition, absl::Time deadline)
-    ABSL_EXCLUSIVE_LOCK_FUNCTION(mu) override {
+  bool MutexLockWhenWithDeadline(absl::Mutex* mu,
+                                 const absl::Condition& condition,
+                                 absl::Time deadline)
+      ABSL_EXCLUSIVE_LOCK_FUNCTION(mu) override {
     return mu->LockWhenWithDeadline(condition, deadline);
   }
 };
@@ -57,12 +58,9 @@ SimpleClock& ProtocolDriver::GetClock() {
   return real_clock;
 }
 
-absl::StatusOr<std::string> ProtocolDriverClient::Preconnect() {
-  return "";
-}
+absl::StatusOr<std::string> ProtocolDriverClient::Preconnect() { return ""; }
 
 void ProtocolDriverServer::HandleConnectFailure(
-    std::string_view local_connection_info) {
-}
+    std::string_view local_connection_info) {}
 
 }  // namespace distbench

--- a/protocol_driver.h
+++ b/protocol_driver.h
@@ -16,10 +16,11 @@
 #define DISTBENCH_PROTOCOL_DRIVER_H_
 
 #include <string_view>
-#include "distbench.pb.h"
+
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/synchronization/notification.h"
+#include "distbench.pb.h"
 #include "grpc_wrapper.h"
 
 namespace distbench {
@@ -61,16 +62,17 @@ class SimpleClock {
  public:
   virtual ~SimpleClock() = default;
   virtual absl::Time Now() = 0;
-  virtual bool MutexLockWhenWithDeadline(
-      absl::Mutex* mu, const absl::Condition& condition, absl::Time deadline)
-    ABSL_EXCLUSIVE_LOCK_FUNCTION(mu) = 0;
+  virtual bool MutexLockWhenWithDeadline(absl::Mutex* mu,
+                                         const absl::Condition& condition,
+                                         absl::Time deadline)
+      ABSL_EXCLUSIVE_LOCK_FUNCTION(mu) = 0;
 };
 
 class ProtocolDriverClient {
  public:
   virtual ~ProtocolDriverClient() {}
   virtual absl::Status InitializeClient(
-      const ProtocolDriverOptions &pd_opts) = 0;
+      const ProtocolDriverOptions& pd_opts) = 0;
 
   // Client interface =========================================================
   virtual void SetNumPeers(int num_peers) = 0;
@@ -96,13 +98,12 @@ class ProtocolDriverClient {
 class ProtocolDriverServer {
  public:
   virtual ~ProtocolDriverServer() {}
-  virtual absl::Status InitializeServer(
-      const ProtocolDriverOptions &pd_opts, int* port) = 0;
+  virtual absl::Status InitializeServer(const ProtocolDriverOptions& pd_opts,
+                                        int* port) = 0;
 
   // Server interface =========================================================
   virtual void SetHandler(
-      std::function<std::function<void ()> (ServerRpcState* state)> handler)
-      = 0;
+      std::function<std::function<void()>(ServerRpcState* state)> handler) = 0;
   // Return the address of a running server that a client can connect to, or
   // actually establish a single conection, given the opaque data from the
   // initiator. E.g. allocate an unconnected RoCE queue pair, and connect it
@@ -120,11 +121,12 @@ class ProtocolDriverServer {
   virtual std::vector<TransportStat> GetTransportStats() = 0;
 };
 
-class ProtocolDriver: public ProtocolDriverClient, public ProtocolDriverServer {
+class ProtocolDriver : public ProtocolDriverClient,
+                       public ProtocolDriverServer {
  public:
   virtual ~ProtocolDriver() {}
-  virtual absl::Status Initialize(
-      const ProtocolDriverOptions &pd_opts, int* port) = 0;
+  virtual absl::Status Initialize(const ProtocolDriverOptions& pd_opts,
+                                  int* port) = 0;
 
   // Misc interface ===========================================================
   virtual SimpleClock& GetClock();

--- a/protocol_driver_allocator.cc
+++ b/protocol_driver_allocator.cc
@@ -17,7 +17,6 @@
 #include "protocol_driver_grpc.h"
 #include "protocol_driver_grpc_async_callback.h"
 
-
 namespace distbench {
 
 absl::StatusOr<std::unique_ptr<ProtocolDriver>> AllocateProtocolDriver(

--- a/protocol_driver_grpc.h
+++ b/protocol_driver_grpc.h
@@ -26,14 +26,14 @@ class ProtocolDriverClientGrpc : public ProtocolDriverClient {
   ProtocolDriverClientGrpc();
   ~ProtocolDriverClientGrpc() override;
 
-  absl::Status InitializeClient(const ProtocolDriverOptions &pd_opts) override;
+  absl::Status InitializeClient(const ProtocolDriverOptions& pd_opts) override;
 
   void SetNumPeers(int num_peers) override;
 
   // Allocate local resources that are needed to establish a connection
   // E.g. an unconnected RoCE QueuePair. Returns opaque data. If no local
   // resources are needed, this is a NOP.
-  //absl::StatusOr<std::string> Preconnect() override;
+  // absl::StatusOr<std::string> Preconnect() override;
 
   // Actually establish a conection, given the opaque data from the
   // the responder. E.g. connect the local and remote RoCE queue pairs.
@@ -45,6 +45,7 @@ class ProtocolDriverClientGrpc : public ProtocolDriverClient {
   void ShutdownClient() override;
 
   virtual std::vector<TransportStat> GetTransportStats() override;
+
  private:
   void RpcCompletionThread();
   absl::Notification shutdown_;
@@ -59,18 +60,18 @@ class ProtocolDriverServerGrpc : public ProtocolDriverServer {
   ProtocolDriverServerGrpc();
   ~ProtocolDriverServerGrpc() override;
 
-  absl::Status InitializeServer(
-      const ProtocolDriverOptions &pd_opts, int* port) override;
+  absl::Status InitializeServer(const ProtocolDriverOptions& pd_opts,
+                                int* port) override;
 
-  void SetHandler(
-      std::function<std::function<void ()> (ServerRpcState* state)> handler)
-      override;
+  void SetHandler(std::function<std::function<void()>(ServerRpcState* state)>
+                      handler) override;
   absl::StatusOr<std::string> HandlePreConnect(
       std::string_view remote_connection_info, int peer) override;
   void ShutdownServer() override;
   void HandleConnectFailure(std::string_view local_connection_info) override;
 
   std::vector<TransportStat> GetTransportStats() override;
+
  private:
   std::unique_ptr<Traffic::Service> traffic_service_;
   std::unique_ptr<grpc::Server> server_;
@@ -84,20 +85,19 @@ class ProtocolDriverGrpc : public ProtocolDriver {
   ProtocolDriverGrpc();
   ~ProtocolDriverGrpc() override;
 
-  absl::Status Initialize(
-      const ProtocolDriverOptions &pd_opts, int* port) override;
-  absl::Status InitializeClient(const ProtocolDriverOptions &pd_opts) override;
-  absl::Status InitializeServer(
-      const ProtocolDriverOptions &pd_opts, int *port) override;
+  absl::Status Initialize(const ProtocolDriverOptions& pd_opts,
+                          int* port) override;
+  absl::Status InitializeClient(const ProtocolDriverOptions& pd_opts) override;
+  absl::Status InitializeServer(const ProtocolDriverOptions& pd_opts,
+                                int* port) override;
 
-  void SetHandler(
-      std::function<std::function<void ()> (ServerRpcState* state)> handler
-      ) override;
+  void SetHandler(std::function<std::function<void()>(ServerRpcState* state)>
+                      handler) override;
   void SetNumPeers(int num_peers) override;
 
   // Connects to the actual GRPC service.
-  absl::Status HandleConnect(
-      std::string remote_connection_info, int peer) override;
+  absl::Status HandleConnect(std::string remote_connection_info,
+                             int peer) override;
 
   // Returns the address of the GRPC service.
   absl::StatusOr<std::string> HandlePreConnect(

--- a/protocol_driver_grpc_async_callback.h
+++ b/protocol_driver_grpc_async_callback.h
@@ -26,26 +26,26 @@ class ProtocolDriverClientGrpcAsyncCallback : public ProtocolDriverClient {
   ProtocolDriverClientGrpcAsyncCallback();
   ~ProtocolDriverClientGrpcAsyncCallback() override;
 
-  absl::Status InitializeClient(
-      const ProtocolDriverOptions &pd_opts) override;
+  absl::Status InitializeClient(const ProtocolDriverOptions& pd_opts) override;
 
   void SetNumPeers(int num_peers) override;
 
   // Allocate local resources that are needed to establish a connection
   // E.g. an unconnected RoCE QueuePair. Returns opaque data. If no local
   // resources are needed, this is a NOP.
-  //absl::StatusOr<std::string> Preconnect() override;
+  // absl::StatusOr<std::string> Preconnect() override;
 
   // Actually establish a conection, given the opaque data from the
   // the responder. E.g. connect the local and remote RoCE queue pairs.
   absl::Status HandleConnect(std::string remote_connection_info,
-                                     int peer) override;
+                             int peer) override;
   void InitiateRpc(int peer_index, ClientRpcState* state,
-                           std::function<void(void)> done_callback) override;
+                   std::function<void(void)> done_callback) override;
   void ChurnConnection(int peer) override;
   void ShutdownClient() override;
 
   virtual std::vector<TransportStat> GetTransportStats() override;
+
  private:
   absl::Notification shutdown_;
   std::atomic<int> pending_rpcs_ = 0;
@@ -57,18 +57,18 @@ class ProtocolDriverServerGrpcAsyncCallback : public ProtocolDriverServer {
   ProtocolDriverServerGrpcAsyncCallback();
   ~ProtocolDriverServerGrpcAsyncCallback() override;
 
-  absl::Status InitializeServer(
-      const ProtocolDriverOptions &pd_opts, int* port) override;
+  absl::Status InitializeServer(const ProtocolDriverOptions& pd_opts,
+                                int* port) override;
 
-  void SetHandler(
-      std::function<std::function<void ()> (ServerRpcState* state)> handler)
-      override;
+  void SetHandler(std::function<std::function<void()>(ServerRpcState* state)>
+                      handler) override;
   absl::StatusOr<std::string> HandlePreConnect(
       std::string_view remote_connection_info, int peer) override;
   void ShutdownServer() override;
   void HandleConnectFailure(std::string_view local_connection_info) override;
 
   std::vector<TransportStat> GetTransportStats() override;
+
  private:
   std::unique_ptr<Traffic::ExperimentalCallbackService> traffic_service_;
   std::unique_ptr<grpc::Server> server_;
@@ -82,21 +82,19 @@ class ProtocolDriverGrpcAsyncCallback : public ProtocolDriver {
   ProtocolDriverGrpcAsyncCallback();
   ~ProtocolDriverGrpcAsyncCallback() override;
 
-  absl::Status Initialize(
-      const ProtocolDriverOptions &pd_opts, int* port) override;
-  absl::Status InitializeClient(
-      const ProtocolDriverOptions &pd_opts) override;
-  absl::Status InitializeServer(
-      const ProtocolDriverOptions &pd_opts, int *port) override;
+  absl::Status Initialize(const ProtocolDriverOptions& pd_opts,
+                          int* port) override;
+  absl::Status InitializeClient(const ProtocolDriverOptions& pd_opts) override;
+  absl::Status InitializeServer(const ProtocolDriverOptions& pd_opts,
+                                int* port) override;
 
-  void SetHandler(
-      std::function<std::function<void ()> (ServerRpcState* state)> handler
-      ) override;
+  void SetHandler(std::function<std::function<void()>(ServerRpcState* state)>
+                      handler) override;
   void SetNumPeers(int num_peers) override;
 
   // Connects to the actual GRPC service.
-  absl::Status HandleConnect(
-      std::string remote_connection_info, int peer) override;
+  absl::Status HandleConnect(std::string remote_connection_info,
+                             int peer) override;
 
   // Returns the address of the GRPC service.
   absl::StatusOr<std::string> HandlePreConnect(


### PR DESCRIPTION
Format all .cc and .h files with clang-format using the Google style.

All files can easily be formatted by doing:
 make clang-format

Also, pre-commit hooks (need to be enabled by the user, see git_hooks/README.md) are provided to help maintains the style.