### PR TITLE
Add a simple threadpool to reduce the high number of threads created in some cases

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -130,6 +130,7 @@ cc_library(
     ],
     deps = [
         ":distbench_cc_grpc_proto",
+        ":distbench_threadpool_lib",
         ":distbench_utils",
         ":protocol_driver_api",
         "@com_github_grpc_grpc//:grpc++",
@@ -253,6 +254,29 @@ cc_library(
         "@com_google_absl//absl/random",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc++_reflection",
+    ],
+)
+
+cc_library(
+    name = "distbench_threadpool_lib",
+    srcs = ["distbench_threadpool.cc"],
+    hdrs = ["distbench_threadpool.h"],
+    deps = [
+        ":distbench_utils",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "distbench_threadpool_test",
+    size = "medium",
+    srcs = ["distbench_threadpool_test.cc", "gtest_utils.h"],
+    deps = [
+        ":distbench_threadpool_lib",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/distbench_threadpool.cc
+++ b/distbench_threadpool.cc
@@ -1,0 +1,53 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "distbench_threadpool.h"
+
+namespace distbench {
+
+DistbenchThreadpool::DistbenchThreadpool(int nb_threads) {
+  auto task_runner = [&]() {
+    do {
+      std::function<void()> task;
+      {
+        absl::MutexLock m(&mutex_);
+        if (work_queue_.empty()) {
+          if (shutdown_.HasBeenNotified()) return;
+          continue;
+        }
+        task = work_queue_.front();
+        work_queue_.pop();
+      }
+      task();
+    } while (true);
+  };
+
+  for (int i = 0; i < nb_threads; i++) {
+    threads_.push_back(RunRegisteredThread("ThreadPool", task_runner));
+  }
+}
+
+DistbenchThreadpool::~DistbenchThreadpool() {
+  shutdown_.Notify();
+  for (auto& thread : threads_) {
+    thread.join();
+  }
+}
+
+void DistbenchThreadpool::AddWork(std::function<void()> function) {
+  absl::MutexLock m(&mutex_);
+  work_queue_.push(function);
+}
+
+}  // namespace distbench

--- a/distbench_threadpool.h
+++ b/distbench_threadpool.h
@@ -1,0 +1,42 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DISTBENCH_DISTBENCH_THREADPOOL_H_
+#define DISTBENCH_DISTBENCH_THREADPOOL_H_
+
+#include <queue>
+#include <thread>
+#include <vector>
+
+#include "absl/synchronization/notification.h"
+#include "distbench_utils.h"
+
+namespace distbench {
+
+class DistbenchThreadpool {
+ public:
+  DistbenchThreadpool(int nb_threads);
+  ~DistbenchThreadpool();
+  void AddWork(std::function<void()> function);
+
+ private:
+  mutable absl::Mutex mutex_;
+  absl::Notification shutdown_;
+  std::vector<std::thread> threads_;
+  std::queue<std::function<void()> > work_queue_;
+};
+
+}  // namespace distbench
+
+#endif  // DISTBENCH_DISTBENCH_THREADPOOL_H_

--- a/distbench_threadpool_test.cc
+++ b/distbench_threadpool_test.cc
@@ -1,0 +1,52 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "distbench_threadpool.h"
+
+#include "gtest/gtest.h"
+#include "gtest_utils.h"
+
+namespace {
+
+TEST(DistBenchThreadPool, Constructor) {
+  distbench::DistbenchThreadpool dtp{4};
+};
+
+TEST(DistBenchThreadPool, PerformSimpleWork) {
+  std::atomic<int> work_counter = 0;
+  {
+    distbench::DistbenchThreadpool dtp{4};
+    for (int i = 0; i < 1000; i++) {
+      dtp.AddWork([&]() { ++work_counter; });
+    }
+  }  // Complete the work of dtp.
+  ASSERT_EQ(work_counter, 1000);
+};
+
+TEST(DistBenchThreadPool, ParallelAddTest) {
+  std::atomic<int> work_counter = 0;
+  {
+    distbench::DistbenchThreadpool dtp_work_performer{4};
+    {
+      distbench::DistbenchThreadpool dtp_work_generator{4};
+      for (int i = 0; i < 1000; i++) {
+        dtp_work_generator.AddWork(
+            [&]() { dtp_work_performer.AddWork([&]() { ++work_counter; }); });
+      }
+    }  // Complete the work of dtp_work_generator.
+  }    // Complete the work of dtp_work_performer.
+  ASSERT_EQ(work_counter, 1000);
+}
+
+}  // namespace

--- a/protocol_driver_test.cc
+++ b/protocol_driver_test.cc
@@ -88,7 +88,7 @@ TEST_P(ProtocolDriverTest, Invoke) {
       return std::function<void()>();
     } else {
       std::function<void()> fct = [=]() {
-        sleep(1);
+        sleep(0.1);
         std::string str;
         s->request->SerializeToString(&str);
         s->SendResponseIfSet();


### PR DESCRIPTION
The threadpool is used by grpc_async_callback to reduce the number of threads created to process RPC responses. In some cases 100'000 threads were created trying to keep up with responses.