### PR TITLE
Fix sleep value with floating point parameter.

### DIFF
--- a/protocol_driver_test.cc
+++ b/protocol_driver_test.cc
@@ -88,7 +88,7 @@ TEST_P(ProtocolDriverTest, Invoke) {
       return std::function<void()>();
     } else {
       std::function<void()> fct = [=]() {
-        sleep(0.1);
+        usleep(100'000);
         std::string str;
         s->request->SerializeToString(&str);
         s->SendResponseIfSet();


### PR DESCRIPTION
sleep(int s) was used with a floating point value which was rounded down
to 0, greatly reducing the chance for the test to catch an issue. Fixing
this.