### PR TITLE
RenameActivity: Rename WasteCpu to ConsumeCpu

### DIFF
--- a/activity.cc
+++ b/activity.cc
@@ -22,8 +22,8 @@ std::unique_ptr<Activity> AllocateActivity(ParsedActivityConfig* config) {
   std::unique_ptr<Activity> activity;
   auto activity_func = config->activity_func;
 
-  if (activity_func == "WasteCpu") {
-    activity = std::make_unique<WasteCpu>();
+  if (activity_func == "ConsumeCpu") {
+    activity = std::make_unique<ConsumeCpu>();
   } else if (activity_func == "PolluteDataCache") {
     activity = std::make_unique<PolluteDataCache>();
   }
@@ -32,9 +32,9 @@ std::unique_ptr<Activity> AllocateActivity(ParsedActivityConfig* config) {
   return activity;
 }
 
-// Activity: WasteCpu
+// Activity: ConsumeCpu
 
-void WasteCpu::DoActivity() {
+void ConsumeCpu::DoActivity() {
   iteration_count_++;
   unsigned int sum = 0;
   std::srand(time(0));
@@ -44,7 +44,7 @@ void WasteCpu::DoActivity() {
   optimization_preventing_num_ = sum;
 }
 
-ActivityLog WasteCpu::GetActivityLog() {
+ActivityLog ConsumeCpu::GetActivityLog() {
   ActivityLog alog;
   if (iteration_count_) {
     auto* am = alog.add_activity_metrics();
@@ -54,12 +54,12 @@ ActivityLog WasteCpu::GetActivityLog() {
   return alog;
 }
 
-void WasteCpu::Initialize(ParsedActivityConfig* config) {
+void ConsumeCpu::Initialize(ParsedActivityConfig* config) {
   rand_array.resize(config->waste_cpu_config.array_size);
   iteration_count_ = 0;
 }
 
-absl::Status WasteCpu::ValidateConfig(ActivityConfig& ac) {
+absl::Status ConsumeCpu::ValidateConfig(ActivityConfig& ac) {
   auto array_size =
       GetNamedSettingInt64(ac.activity_settings(), "array_size", 1000);
   if (array_size < 1) {

--- a/activity.h
+++ b/activity.h
@@ -52,9 +52,9 @@ class Activity {
 // configuration in ActivityConfig.
 std::unique_ptr<Activity> AllocateActivity(ParsedActivityConfig* config);
 
-// Activity: WasteCpu
+// Activity: ConsumeCpu
 
-class WasteCpu : public Activity {
+class ConsumeCpu : public Activity {
  public:
   void DoActivity() override;
   ActivityLog GetActivityLog() override;
@@ -67,7 +67,7 @@ class WasteCpu : public Activity {
   int64_t optimization_preventing_num_ = 0;
 };
 
-struct WasteCpuConfig {
+struct ConsumeCpuConfig {
   int array_size;
 };
 
@@ -95,7 +95,7 @@ struct PolluteDataCacheConfig {
 };
 
 struct ParsedActivityConfig {
-  struct WasteCpuConfig waste_cpu_config;
+  struct ConsumeCpuConfig waste_cpu_config;
   struct PolluteDataCacheConfig pollute_data_cache_config;
   std::string activity_config_name;
   std::string activity_func;

--- a/distbench_engine.cc
+++ b/distbench_engine.cc
@@ -164,8 +164,8 @@ absl::Status DistBenchEngine::ParseActivityConfig(ActivityConfig& ac) {
       GetNamedSettingString(ac.activity_settings(), "activity_func", "");
   s.activity_config_name = ac.name();
 
-  if (s.activity_func == "WasteCpu") {
-    auto status = WasteCpu::ValidateConfig(ac);
+  if (s.activity_func == "ConsumeCpu") {
+    auto status = ConsumeCpu::ValidateConfig(ac);
     if (!status.ok()) return status;
 
     s.waste_cpu_config.array_size =

--- a/distbench_test_sequencer_test.cc
+++ b/distbench_test_sequencer_test.cc
@@ -640,10 +640,10 @@ TEST(DistBenchTestSequencer, CliqueOpenLoopRpcAntagonistTest) {
 
   TestSequenceParams params;
   params.nb_cliques = nb_cliques;
-  params.activity_name = "WasteCpu2500";
-  params.activity_name_2 = "WasteCpu2500_2";
-  params.activity_func = "WasteCpu";
-  params.activity_func_2 = "WasteCpu";
+  params.activity_name = "ConsumeCpu2500";
+  params.activity_name_2 = "ConsumeCpu2500_2";
+  params.activity_func = "ConsumeCpu";
+  params.activity_func_2 = "ConsumeCpu";
   params.array_size = 2500;
   auto test_sequence = GetCliqueTestSequence(params);
 
@@ -691,8 +691,8 @@ TEST(DistBenchTestSequencer, CliqueClosedLoopRpcAntagonistTest) {
   TestSequenceParams params;
   params.nb_cliques = nb_cliques;
   params.open_loop = false;
-  params.activity_name = "WasteCpu2500";
-  params.activity_func = "WasteCpu";
+  params.activity_name = "ConsumeCpu2500";
+  params.activity_func = "ConsumeCpu";
   params.array_size = 2500;
   auto test_sequence = GetCliqueTestSequence(params);
 
@@ -776,7 +776,7 @@ TEST(DistBenchTestSequencer, PolluteDataCache) {
             test_results.service_logs().instance_logs().end());
 }
 
-TEST(DistBenchTestSequencer, WasteCpuWithMaxIterationCount) {
+TEST(DistBenchTestSequencer, ConsumeCpuWithMaxIterationCount) {
   int nb_cliques = 2;
 
   DistBenchTester tester;
@@ -785,8 +785,8 @@ TEST(DistBenchTestSequencer, WasteCpuWithMaxIterationCount) {
   TestSequenceParams params;
   params.nb_cliques = nb_cliques;
   params.open_loop = false;
-  params.activity_name = "WasteCpu2500";
-  params.activity_func = "WasteCpu";
+  params.activity_name = "ConsumeCpu2500";
+  params.activity_func = "ConsumeCpu";
   params.array_size = 2500;
   params.max_iteration_count = 10;
   auto test_sequence = GetCliqueTestSequence(params);
@@ -832,8 +832,8 @@ TEST(DistBenchTestSequencer, TwoActivitiesWithSameActivityConfig) {
 
   TestSequenceParams params;
   params.nb_cliques = nb_cliques;
-  params.activity_name = "WasteCpu2500";
-  params.activity_func = "WasteCpu";
+  params.activity_name = "ConsumeCpu2500";
+  params.activity_func = "ConsumeCpu";
   params.array_size = 2500;
   params.activity_with_same_config = true;
   auto test_sequence = GetCliqueTestSequence(params);
@@ -882,7 +882,7 @@ TEST(DistBenchTestSequencer, UnknownActivity) {
   TestSequenceParams params;
   params.nb_cliques = nb_cliques;
   params.activity_name = "unknown_activity";
-  params.activity_func = "WasteCpu";
+  params.activity_func = "ConsumeCpu";
   params.array_size = 2500;
   auto test_sequence = GetCliqueTestSequence(params);
 
@@ -903,7 +903,7 @@ TEST(DistBenchTestSequencer, KnownActivityUnknownConfig) {
   params.nb_cliques = nb_cliques;
   params.open_loop = true;
   params.activity_name = "known_activity_unknown_config";
-  params.activity_func = "WasteCpu";
+  params.activity_func = "ConsumeCpu";
   params.array_size = 2500;
   auto test_sequence = GetCliqueTestSequence(params);
 
@@ -923,8 +923,8 @@ TEST(DistBenchTestSequencer, RedefineActivityConfig) {
   TestSequenceParams params;
   params.nb_cliques = nb_cliques;
   params.open_loop = false;
-  params.activity_name = "WasteCpu2500";
-  params.activity_func = "WasteCpu";
+  params.activity_name = "ConsumeCpu2500";
+  params.activity_func = "ConsumeCpu";
   params.array_size = 2500;
   params.duplicate_activity_config = true;
   auto test_sequence = GetCliqueTestSequence(params);
@@ -944,8 +944,8 @@ TEST(DistBenchTestSequencer, PreCheckInvalidActivityConfig) {
 
   TestSequenceParams params;
   params.nb_cliques = nb_cliques;
-  params.activity_name = "WasteCpu2500";
-  params.activity_func = "WasteCpu";
+  params.activity_name = "ConsumeCpu2500";
+  params.activity_func = "ConsumeCpu";
   params.array_size = 2500;
   params.invalid_config = true;
   auto test_sequence = GetCliqueTestSequence(params);


### PR DESCRIPTION
Got a comment saying WasteCpu sounded a bit negative. Hence renamed it to **ConsumeCpu**