### PR TITLE
Modify scopes of dtp_work_performer/generator, Add Sleep

### DIFF
--- a/distbench_threadpool_test.cc
+++ b/distbench_threadpool_test.cc
@@ -36,16 +36,13 @@ TEST(DistBenchThreadPool, PerformSimpleWork) {
 
 TEST(DistBenchThreadPool, ParallelAddTest) {
   std::atomic<int> work_counter = 0;
-  {
-    distbench::DistbenchThreadpool dtp_work_performer{4};
-    {
-      distbench::DistbenchThreadpool dtp_work_generator{4};
-      for (int i = 0; i < 1000; i++) {
-        dtp_work_generator.AddWork(
-            [&]() { dtp_work_performer.AddWork([&]() { ++work_counter; }); });
-      }
-    }  // Complete the work of dtp_work_generator.
-  }    // Complete the work of dtp_work_performer.
+  distbench::DistbenchThreadpool dtp_work_performer{4};
+  distbench::DistbenchThreadpool dtp_work_generator{4};
+  for (int i = 0; i < 1000; i++) {
+    dtp_work_generator.AddWork(
+      [&]() { dtp_work_performer.AddWork([&]() { ++work_counter; }); });
+  }
+  sleep(5);
   ASSERT_EQ(work_counter, 1000);
 }
 


### PR DESCRIPTION
ParallelAddTest has two levels of threadpools - dtp_work_performer and dtp_work_generator.
The problem with memory leak was that the dtp_work_generator was going out of scope before dtp_work_performer completed all the work. Modifying the scopes rectifies this.

The sleep is required just before the ASSERT at the end so that threadpools get enough time to complete the work.
