### PR TITLE
Add logs if activity_logs is not empty

### DIFF
--- a/distbench_node_manager.cc
+++ b/distbench_node_manager.cc
@@ -177,7 +177,7 @@ grpc::Status NodeManager::GetTrafficResult(
   auto& instance_logs = *service_logs.mutable_instance_logs();
   for (const auto& service_engine : service_engines_) {
     auto log = service_engine.second->GetLogs();
-    if (log.peer_logs().empty()) continue;
+    if (log.peer_logs().empty() && log.activity_logs().empty()) continue;
     instance_logs[service_engine.first] = std::move(log);
   }
 


### PR DESCRIPTION
We must **NOT** add `service_engine`'s log to the instance_logs **ONLY IF BOTH** `peer_logs` and `activity_logs` are missing. Until now, we were checking only for absence of `peer_logs`.

This was missed previously because the `activity` testing was done on modified `clique` tests. The issue was caught when I added a `client_server` test with server activity where the server did not have any `peer_logs` but did have `activity_logs`