### PR TITLE
Fixed the link at the bottom of getting_started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,4 +83,4 @@ bazel run --compilation_mode=dbg :distbench -- node_manager --test_sequencer=loc
 ## Distbench Workloads
 
 Once `simple_test.sh` is running, please look at the
-[Distbench Workloads](workloads/README.md) for more workloads to run.
+[Distbench Workloads](../workloads/README.md) for more workloads to run.


### PR DESCRIPTION
The link at the bottom of docs/getting_started.md is in a different directory than that of the workloads/READ.me but now opens a tab to the correct file. This addresses issue #190.