### PR TITLE
Homa

### DIFF
--- a/homa_experiments/homa_test_w1.config
+++ b/homa_experiments/homa_test_w1.config
@@ -1,0 +1,207 @@
+tests {
+  attributes: { key: 'workload' value: 'w1' }
+  attributes: { key: 'max_message_length' value: '1000000' }
+  attributes: { key: 'min_bucket_frac' value: '0.0025' }
+  attributes: { key: 'max_size_ratio' value: '1.2' }
+  attributes: { key: 'Gbps' value: '1' }
+  attributes: { key: 'num_nodes' value: '10' }
+  attributes: { key: 'test_duration_s' value: '10' }
+  protocol_driver_options {
+    name: 'default_protocol_driver_options'
+    protocol_name: 'homa'
+  }
+  name: 'homa_test'
+  services {
+    name: 'clique'
+    count: 10
+  }
+  action_lists {
+    name: 'clique'
+    action_names: 'clique_queries'
+  }
+  actions {
+    name: 'clique_queries'
+    iterations {
+      max_duration_us: 10000000
+      open_loop_interval_ns: 1543
+      open_loop_interval_distribution: 'exponential_distribution'
+      warmup_iterations: 1500
+    }
+    rpc_name: 'clique_query'
+  }
+  rpc_descriptions {
+    name: 'clique_query'
+    client: 'clique'
+    server: 'clique'
+    fanout_filter: 'random'
+    distribution_config_name: "dist_config"
+  }
+  action_lists {
+    name: 'clique_query'
+    # no actions, NOP
+  }
+  overload_limits {
+    max_pending_rpcs: 5000
+  }
+  distribution_config {
+    name: "dist_config"
+    field_names: "payload_size"
+    cdf_points { value: 8, cdf: 0.3109399999999999942 }
+    cdf_points { value: 9, cdf: 0.3193099999999999827 }
+    cdf_points { value: 10, cdf: 0.3276800000000000268 }
+    cdf_points { value: 11, cdf: 0.4175699999999999967 }
+    cdf_points { value: 13, cdf: 0.4217500000000000138 }
+    cdf_points { value: 14, cdf: 0.4415499999999999980 }
+    cdf_points { value: 15, cdf: 0.4699999999999999734 }
+    cdf_points { value: 16, cdf: 0.4748218165010569813 }
+    cdf_points { value: 18, cdf: 0.4785984461593190131 }
+    cdf_points { value: 19, cdf: 0.4812840920236409747 }
+    cdf_points { value: 20, cdf: 0.4841111028392229843 }
+    cdf_points { value: 22, cdf: 0.4886302767145859760 }
+    cdf_points { value: 24, cdf: 0.4935029362474480097 }
+    cdf_points { value: 26, cdf: 0.4969585691553319862 }
+    cdf_points { value: 27, cdf: 0.5005876293882709493 }
+    cdf_points { value: 29, cdf: 0.5043967392292290075 }
+    cdf_points { value: 31, cdf: 0.5083925285379039538 }
+    cdf_points { value: 33, cdf: 0.5125816004640709744 }
+    cdf_points { value: 35, cdf: 0.5169704929453570186 }
+    cdf_points { value: 37, cdf: 0.5215656357741600413 }
+    cdf_points { value: 39, cdf: 0.5263733030457670159 }
+    cdf_points { value: 41, cdf: 0.5313995608359339817 }
+    cdf_points { value: 43, cdf: 0.5339964859686240350 }
+    cdf_points { value: 44, cdf: 0.5366502100025489774 }
+    cdf_points { value: 45, cdf: 0.5393614064125840102 }
+    cdf_points { value: 47, cdf: 0.5421307240634249958 }
+    cdf_points { value: 48, cdf: 0.5449587850013269952 }
+    cdf_points { value: 50, cdf: 0.5478461821719410318 }
+    cdf_points { value: 51, cdf: 0.5507934770660020130 }
+    cdf_points { value: 53, cdf: 0.5538011972950660500 }
+    cdf_points { value: 54, cdf: 0.5568698340999279628 }
+    cdf_points { value: 56, cdf: 0.5599998397948749984 }
+    cdf_points { value: 57, cdf: 0.5631916251514169636 }
+    cdf_points { value: 59, cdf: 0.5664455567257139501 }
+    cdf_points { value: 61, cdf: 0.5697619541344619565 }
+    cdf_points { value: 63, cdf: 0.5731410872846219862 }
+    cdf_points { value: 65, cdf: 0.5765831735629960431 }
+    cdf_points { value: 67, cdf: 0.5800883749922850496 }
+    cdf_points { value: 69, cdf: 0.5836567953609510528 }
+    cdf_points { value: 71, cdf: 0.5872884773348799881 }
+    cdf_points { value: 73, cdf: 0.5909833995595410450 }
+    cdf_points { value: 75, cdf: 0.5947414737620579928 }
+    cdf_points { value: 77, cdf: 0.5985625418633140349 }
+    cdf_points { value: 79, cdf: 0.6024463731109509501 }
+    cdf_points { value: 82, cdf: 0.6063926612448290454 }
+    cdf_points { value: 84, cdf: 0.6104010217072359801 }
+    cdf_points { value: 87, cdf: 0.6144709889108409540 }
+    cdf_points { value: 89, cdf: 0.6186020135780490037 }
+    cdf_points { value: 92, cdf: 0.6227934601661020420 }
+    cdf_points { value: 95, cdf: 0.6270446043928540325 }
+    cdf_points { value: 97, cdf: 0.6313546308787659767 }
+    cdf_points { value: 100, cdf: 0.6357226309211809756 }
+    cdf_points { value: 103, cdf: 0.6401476004173990431 }
+    cdf_points { value: 106, cdf: 0.6446284379535169862 }
+    cdf_points { value: 110, cdf: 0.6491639430762790042 }
+    cdf_points { value: 113, cdf: 0.6537528147654749766 }
+    cdf_points { value: 116, cdf: 0.6583936501245409856 }
+    cdf_points { value: 120, cdf: 0.6630849433070710175 }
+    cdf_points { value: 123, cdf: 0.6678250846968980525 }
+    cdf_points { value: 127, cdf: 0.6726123603591690481 }
+    cdf_points { value: 131, cdf: 0.6774449517795689824 }
+    cdf_points { value: 135, cdf: 0.6823209359083529657 }
+    cdf_points { value: 139, cdf: 0.6872382855252270328 }
+    cdf_points { value: 143, cdf: 0.6921948699404070204 }
+    cdf_points { value: 147, cdf: 0.6971884560461979463 }
+    cdf_points { value: 151, cdf: 0.7022167097323980256 }
+    cdf_points { value: 156, cdf: 0.7072771976775610314 }
+    cdf_points { value: 161, cdf: 0.7123673895267239597 }
+    cdf_points { value: 165, cdf: 0.7174846604646299975 }
+    cdf_points { value: 170, cdf: 0.7226262941917009908 }
+    cdf_points { value: 175, cdf: 0.7277894863081160182 }
+    cdf_points { value: 181, cdf: 0.7329713481092400285 }
+    cdf_points { value: 186, cdf: 0.7381689107934450433 }
+    cdf_points { value: 191, cdf: 0.7433791300809849956 }
+    cdf_points { value: 197, cdf: 0.7485988912400709516 }
+    cdf_points { value: 203, cdf: 0.7538250145137089797 }
+    cdf_points { value: 209, cdf: 0.7590542609381319972 }
+    cdf_points { value: 215, cdf: 0.7642833385408640545 }
+    cdf_points { value: 222, cdf: 0.7695089089036519781 }
+    cdf_points { value: 228, cdf: 0.7747275940725559806 }
+    cdf_points { value: 235, cdf: 0.7799359837946779894 }
+    cdf_points { value: 242, cdf: 0.7851306430580929918 }
+    cdf_points { value: 249, cdf: 0.7903081199087490516 }
+    cdf_points { value: 257, cdf: 0.7954649535153639484 }
+    cdf_points { value: 264, cdf: 0.8005976824507240464 }
+    cdf_points { value: 272, cdf: 0.8057028531552650197 }
+    cdf_points { value: 280, cdf: 0.8107770285465449867 }
+    cdf_points { value: 289, cdf: 0.8158167967360540063 }
+    cdf_points { value: 297, cdf: 0.8208187798129289448 }
+    cdf_points { value: 306, cdf: 0.8257796426525270128 }
+    cdf_points { value: 315, cdf: 0.8306961017064280473 }
+    cdf_points { value: 324, cdf: 0.8355649337294509538 }
+    cdf_points { value: 334, cdf: 0.8403829843985040071 }
+    cdf_points { value: 344, cdf: 0.8451471767777960498 }
+    cdf_points { value: 354, cdf: 0.8498545195849099843 }
+    cdf_points { value: 365, cdf: 0.8545021152126379693 }
+    cdf_points { value: 376, cdf: 0.8590871674622759802 }
+    cdf_points { value: 387, cdf: 0.8636069889452020476 }
+    cdf_points { value: 398, cdf: 0.8680590081111400069 }
+    cdf_points { value: 410, cdf: 0.8724407758634360466 }
+    cdf_points { value: 422, cdf: 0.8767499717239419788 }
+    cdf_points { value: 435, cdf: 0.8809844095127929986 }
+    cdf_points { value: 448, cdf: 0.8851420425112890289 }
+    cdf_points { value: 461, cdf: 0.8892209680794119775 }
+    cdf_points { value: 475, cdf: 0.8932194317030319741 }
+    cdf_points { value: 489, cdf: 0.8971358304496710456 }
+    cdf_points { value: 503, cdf: 0.9009687158156689524 }
+    cdf_points { value: 518, cdf: 0.9047167959517640190 }
+    cdf_points { value: 534, cdf: 0.9083789372583830346 }
+    cdf_points { value: 549, cdf: 0.9119541653462680530 }
+    cdf_points { value: 566, cdf: 0.9154416653624679601 }
+    cdf_points { value: 582, cdf: 0.9188407816860899580 }
+    cdf_points { value: 600, cdf: 0.9221510170024820319 }
+    cdf_points { value: 618, cdf: 0.9253720307687559599 }
+    cdf_points { value: 636, cdf: 0.9285036370875660028 }
+    cdf_points { value: 655, cdf: 0.9315458020099369740 }
+    cdf_points { value: 674, cdf: 0.9344986402915449464 }
+    cdf_points { value: 694, cdf: 0.9373624116302250453 }
+    cdf_points { value: 715, cdf: 0.9401375164155170161 }
+    cdf_points { value: 736, cdf: 0.9428244910238270382 }
+    cdf_points { value: 758, cdf: 0.9454240026951470366 }
+    cdf_points { value: 780, cdf: 0.9479368440293090003 }
+    cdf_points { value: 827, cdf: 0.9527062775172560061 }
+    cdf_points { value: 877, cdf: 0.9571414102249290456 }
+    cdf_points { value: 930, cdf: 0.9612524650907540158 }
+    cdf_points { value: 986, cdf: 0.9650510504688659674 }
+    cdf_points { value: 1046, cdf: 0.9685499355427850121 }
+    cdf_points { value: 1108, cdf: 0.9717628250231740150 }
+    cdf_points { value: 1175, cdf: 0.9747041378301819492 }
+    cdf_points { value: 1246, cdf: 0.9773887939541809899 }
+    cdf_points { value: 1360, cdf: 0.9809678756214329498 }
+    cdf_points { value: 1485, cdf: 0.9840554147868979529 }
+    cdf_points { value: 1621, cdf: 0.9867024147466819661 }
+    cdf_points { value: 1822, cdf: 0.9896313360408489634 }
+    cdf_points { value: 2109, cdf: 0.9924800959063330152 }
+    cdf_points { value: 2514, cdf: 0.9949561129152809658 }
+    cdf_points { value: 2996, cdf: 0.9966630891598290409 }
+    cdf_points { value: 3570, cdf: 0.9978193624482839530 }
+    cdf_points { value: 4255, cdf: 0.9985904222213870529 }
+    cdf_points { value: 5070, cdf: 0.9990975334783279704 }
+    cdf_points { value: 6043, cdf: 0.9994270254744509474 }
+    cdf_points { value: 7201, cdf: 0.9996388567271979886 }
+    cdf_points { value: 8582, cdf: 0.9997737999203010206 }
+    cdf_points { value: 10227, cdf: 0.9998590853619879759 }
+    cdf_points { value: 12188, cdf: 0.9999126213814349962 }
+    cdf_points { value: 14524, cdf: 0.9999460323880380308 }
+    cdf_points { value: 17309, cdf: 0.9999667803674180400 }
+    cdf_points { value: 20627, cdf: 0.9999796103412339487 }
+    cdf_points { value: 24582, cdf: 0.9999875156003770194 }
+    cdf_points { value: 29295, cdf: 0.9999923716633120074 }
+    cdf_points { value: 34911, cdf: 0.9999953469818190221 }
+    cdf_points { value: 41604, cdf: 0.9999971659988730055 }
+    cdf_points { value: 49580, cdf: 0.9999982760462809983 }
+    cdf_points { value: 59086, cdf: 0.9999989523982280026 }
+    cdf_points { value: 70413, cdf: 0.9999993639612310137 }
+    cdf_points { value: 83912, cdf: 0.9999996141235290015 }
+    cdf_points { value: 100000, cdf: 1.0000000000000000000 }
+  }
+}

--- a/homa_experiments/homa_test_w2.config
+++ b/homa_experiments/homa_test_w2.config
@@ -1,0 +1,145 @@
+tests {
+  attributes: { key: 'workload' value: 'w2' }
+  attributes: { key: 'max_message_length' value: '1000000' }
+  attributes: { key: 'min_bucket_frac' value: '0.0025' }
+  attributes: { key: 'max_size_ratio' value: '1.2' }
+  attributes: { key: 'Gbps' value: '1' }
+  attributes: { key: 'num_nodes' value: '10' }
+  attributes: { key: 'test_duration_s' value: '10' }
+  protocol_driver_options {
+    name: 'default_protocol_driver_options'
+    protocol_name: 'homa'
+  }
+  name: 'homa_test'
+  services {
+    name: 'clique'
+    count: 10
+  }
+  action_lists {
+    name: 'clique'
+    action_names: 'clique_queries'
+  }
+  actions {
+    name: 'clique_queries'
+    iterations {
+      max_duration_us: 10000000
+      open_loop_interval_ns: 3527
+      open_loop_interval_distribution: 'exponential_distribution'
+      warmup_iterations: 1500
+    }
+    rpc_name: 'clique_query'
+  }
+  rpc_descriptions {
+    name: 'clique_query'
+    client: 'clique'
+    server: 'clique'
+    fanout_filter: 'random'
+    distribution_config_name: "dist_config"
+  }
+  action_lists {
+    name: 'clique_query'
+    # no actions, NOP
+  }
+  overload_limits {
+    max_pending_rpcs: 5000
+  }
+  distribution_config {
+    name: "dist_config"
+    field_names: "payload_size"
+    cdf_points { value: 8, cdf: 0.1701076279091389976 }
+    cdf_points { value: 32, cdf: 0.1890084754545990064 }
+    cdf_points { value: 34, cdf: 0.2027512207344260020 }
+    cdf_points { value: 36, cdf: 0.2164939660142539968 }
+    cdf_points { value: 38, cdf: 0.2302367112940819915 }
+    cdf_points { value: 40, cdf: 0.2439794565739099863 }
+    cdf_points { value: 43, cdf: 0.2577222018537380088 }
+    cdf_points { value: 46, cdf: 0.2714649471335660036 }
+    cdf_points { value: 49, cdf: 0.2852076924133939984 }
+    cdf_points { value: 53, cdf: 0.2989504376932219931 }
+    cdf_points { value: 58, cdf: 0.3126931829730499879 }
+    cdf_points { value: 64, cdf: 0.3264359282528779826 }
+    cdf_points { value: 71, cdf: 0.3294893773217930089 }
+    cdf_points { value: 80, cdf: 0.3325428263907089788 }
+    cdf_points { value: 91, cdf: 0.3355962754596240050 }
+    cdf_points { value: 107, cdf: 0.3386497245285389757 }
+    cdf_points { value: 128, cdf: 0.3417031735974550011 }
+    cdf_points { value: 135, cdf: 0.3539168103019489919 }
+    cdf_points { value: 142, cdf: 0.3661304470064429828 }
+    cdf_points { value: 151, cdf: 0.3783440837109369737 }
+    cdf_points { value: 160, cdf: 0.3905577204154310200 }
+    cdf_points { value: 171, cdf: 0.4027713571199250109 }
+    cdf_points { value: 183, cdf: 0.4149849938244190017 }
+    cdf_points { value: 197, cdf: 0.4271986305289129926 }
+    cdf_points { value: 213, cdf: 0.4394122672334069835 }
+    cdf_points { value: 233, cdf: 0.4516259039379009743 }
+    cdf_points { value: 256, cdf: 0.4638395406423950207 }
+    cdf_points { value: 269, cdf: 0.5084956485779450475 }
+    cdf_points { value: 284, cdf: 0.5531517565134950187 }
+    cdf_points { value: 301, cdf: 0.5978078644490449900 }
+    cdf_points { value: 320, cdf: 0.6424639723845949613 }
+    cdf_points { value: 341, cdf: 0.6871200803201450436 }
+    cdf_points { value: 366, cdf: 0.7317761882556950148 }
+    cdf_points { value: 394, cdf: 0.7764322961912449861 }
+    cdf_points { value: 427, cdf: 0.8210884041267949573 }
+    cdf_points { value: 465, cdf: 0.8657445120623450396 }
+    cdf_points { value: 512, cdf: 0.9104006199978950109 }
+    cdf_points { value: 539, cdf: 0.9151715716495210096 }
+    cdf_points { value: 569, cdf: 0.9199425233011470082 }
+    cdf_points { value: 602, cdf: 0.9247134749527730069 }
+    cdf_points { value: 640, cdf: 0.9294844266043990055 }
+    cdf_points { value: 683, cdf: 0.9342553782560250042 }
+    cdf_points { value: 731, cdf: 0.9390263299076510028 }
+    cdf_points { value: 788, cdf: 0.9437972815592760023 }
+    cdf_points { value: 853, cdf: 0.9485682332109020010 }
+    cdf_points { value: 931, cdf: 0.9533391848625279996 }
+    cdf_points { value: 1024, cdf: 0.9581101365141539983 }
+    cdf_points { value: 1138, cdf: 0.9626902517668759485 }
+    cdf_points { value: 1280, cdf: 0.9672703670195990089 }
+    cdf_points { value: 1463, cdf: 0.9718504822723209591 }
+    cdf_points { value: 1707, cdf: 0.9764305975250430203 }
+    cdf_points { value: 2048, cdf: 0.9810107127777659697 }
+    cdf_points { value: 2276, cdf: 0.9838732825779109570 }
+    cdf_points { value: 2560, cdf: 0.9867358523780570545 }
+    cdf_points { value: 2926, cdf: 0.9895984221782030410 }
+    cdf_points { value: 3413, cdf: 0.9924609919783490275 }
+    cdf_points { value: 3724, cdf: 0.9938922768784219652 }
+    cdf_points { value: 4312, cdf: 0.9956336739037869865 }
+    cdf_points { value: 5120, cdf: 0.9965640102796640143 }
+    cdf_points { value: 5851, cdf: 0.9971842345302489585 }
+    cdf_points { value: 6827, cdf: 0.9978044587808340138 }
+    cdf_points { value: 8192, cdf: 0.9984246830314189580 }
+    cdf_points { value: 9638, cdf: 0.9985678114469990208 }
+    cdf_points { value: 10923, cdf: 0.9986632303907190256 }
+    cdf_points { value: 12603, cdf: 0.9987586493344400296 }
+    cdf_points { value: 14895, cdf: 0.9988540682781600344 }
+    cdf_points { value: 17246, cdf: 0.9989256324859500102 }
+    cdf_points { value: 20480, cdf: 0.9989971966937399861 }
+    cdf_points { value: 23406, cdf: 0.9990449061656000440 }
+    cdf_points { value: 27307, cdf: 0.9990926156374609901 }
+    cdf_points { value: 32768, cdf: 0.9991403251093210480 }
+    cdf_points { value: 38551, cdf: 0.9992029438609120184 }
+    cdf_points { value: 43691, cdf: 0.9992446896953069979 }
+    cdf_points { value: 50412, cdf: 0.9992864355297009782 }
+    cdf_points { value: 59578, cdf: 0.9993281813640959577 }
+    cdf_points { value: 68985, cdf: 0.9994012365742860338 }
+    cdf_points { value: 81920, cdf: 0.9995577834532649586 }
+    cdf_points { value: 93623, cdf: 0.9996621480392510195 }
+    cdf_points { value: 109227, cdf: 0.9997665126252369694 }
+    cdf_points { value: 131072, cdf: 0.9998708772112230303 }
+    cdf_points { value: 154202, cdf: 0.9999021865870190151 }
+    cdf_points { value: 174763, cdf: 0.9999230595042160052 }
+    cdf_points { value: 201649, cdf: 0.9999439324214129954 }
+    cdf_points { value: 238313, cdf: 0.9999648053386099855 }
+    cdf_points { value: 275941, cdf: 0.9999759872635209934 }
+    cdf_points { value: 327680, cdf: 0.9999782236624590315 }
+    cdf_points { value: 374491, cdf: 0.9999797145950839461 }
+    cdf_points { value: 436907, cdf: 0.9999812055277079725 }
+    cdf_points { value: 524288, cdf: 0.9999826964603329982 }
+    cdf_points { value: 573085, cdf: 0.9999844268142999981 }
+    cdf_points { value: 631896, cdf: 0.9999861571682659989 }
+    cdf_points { value: 704160, cdf: 0.9999878875222329988 }
+    cdf_points { value: 795085, cdf: 0.9999896178761999987 }
+    cdf_points { value: 912974, cdf: 0.9999913482301669987 }
+    cdf_points { value: 1000000, cdf: 1.0000000000000000000 }
+  }
+}

--- a/homa_experiments/homa_test_w3.config
+++ b/homa_experiments/homa_test_w3.config
@@ -1,0 +1,163 @@
+tests {
+  attributes: { key: 'workload' value: 'w3' }
+  attributes: { key: 'max_message_length' value: '1000000' }
+  attributes: { key: 'min_bucket_frac' value: '0.0025' }
+  attributes: { key: 'max_size_ratio' value: '1.2' }
+  attributes: { key: 'Gbps' value: '2' }
+  attributes: { key: 'num_nodes' value: '10' }
+  attributes: { key: 'test_duration_s' value: '10' }
+  protocol_driver_options {
+    name: 'default_protocol_driver_options'
+    protocol_name: 'homa'
+  }
+  name: 'homa_test'
+  services {
+    name: 'clique'
+    count: 10
+  }
+  action_lists {
+    name: 'clique'
+    action_names: 'clique_queries'
+  }
+  actions {
+    name: 'clique_queries'
+    iterations {
+      max_duration_us: 10000000
+      open_loop_interval_ns: 10271
+      open_loop_interval_distribution: 'exponential_distribution'
+      warmup_iterations: 1500
+    }
+    rpc_name: 'clique_query'
+  }
+  rpc_descriptions {
+    name: 'clique_query'
+    client: 'clique'
+    server: 'clique'
+    fanout_filter: 'random'
+    distribution_config_name: "dist_config"
+  }
+  action_lists {
+    name: 'clique_query'
+    # no actions, NOP
+  }
+  overload_limits {
+    max_pending_rpcs: 5000
+  }
+  distribution_config {
+    name: "dist_config"
+    field_names: "payload_size"
+    cdf_points { value: 8, cdf: 0.0648826230027598067 }
+    cdf_points { value: 32, cdf: 0.0973239345041398002 }
+    cdf_points { value: 36, cdf: 0.1089132949118340049 }
+    cdf_points { value: 40, cdf: 0.1205026553195280015 }
+    cdf_points { value: 46, cdf: 0.1320920157272230111 }
+    cdf_points { value: 53, cdf: 0.1436813761349169938 }
+    cdf_points { value: 64, cdf: 0.1552707365426110042 }
+    cdf_points { value: 70, cdf: 0.1879878042039699881 }
+    cdf_points { value: 77, cdf: 0.2207048718653280006 }
+    cdf_points { value: 85, cdf: 0.2534219395266870123 }
+    cdf_points { value: 96, cdf: 0.2861390071880450248 }
+    cdf_points { value: 110, cdf: 0.3188560748494039809 }
+    cdf_points { value: 128, cdf: 0.3515731425107629926 }
+    cdf_points { value: 137, cdf: 0.3698640951162460166 }
+    cdf_points { value: 146, cdf: 0.3881550477217289852 }
+    cdf_points { value: 158, cdf: 0.4064460003272120092 }
+    cdf_points { value: 171, cdf: 0.4247369529326949777 }
+    cdf_points { value: 186, cdf: 0.4430279055381780018 }
+    cdf_points { value: 205, cdf: 0.4613188581436610258 }
+    cdf_points { value: 228, cdf: 0.4796098107491449936 }
+    cdf_points { value: 256, cdf: 0.4979007633546280176 }
+    cdf_points { value: 268, cdf: 0.5239935348784430236 }
+    cdf_points { value: 282, cdf: 0.5500863064022579740 }
+    cdf_points { value: 296, cdf: 0.5761790779260730355 }
+    cdf_points { value: 313, cdf: 0.6022718494498879860 }
+    cdf_points { value: 331, cdf: 0.6283646209737030475 }
+    cdf_points { value: 352, cdf: 0.6544573924975179979 }
+    cdf_points { value: 375, cdf: 0.6805501640213329484 }
+    cdf_points { value: 402, cdf: 0.7066429355451480099 }
+    cdf_points { value: 433, cdf: 0.7327357070689629603 }
+    cdf_points { value: 469, cdf: 0.7588284785927780218 }
+    cdf_points { value: 512, cdf: 0.7849212501165929723 }
+    cdf_points { value: 531, cdf: 0.7905125585645840225 }
+    cdf_points { value: 551, cdf: 0.7961038670125749617 }
+    cdf_points { value: 573, cdf: 0.8016951754605660119 }
+    cdf_points { value: 597, cdf: 0.8072864839085569511 }
+    cdf_points { value: 623, cdf: 0.8128777923565480013 }
+    cdf_points { value: 652, cdf: 0.8184691008045390515 }
+    cdf_points { value: 683, cdf: 0.8240604092525299906 }
+    cdf_points { value: 717, cdf: 0.8296517177005210408 }
+    cdf_points { value: 755, cdf: 0.8352430261485119800 }
+    cdf_points { value: 796, cdf: 0.8408343345965030302 }
+    cdf_points { value: 843, cdf: 0.8464256430444939694 }
+    cdf_points { value: 896, cdf: 0.8520169514924850196 }
+    cdf_points { value: 956, cdf: 0.8576082599404759588 }
+    cdf_points { value: 1024, cdf: 0.8631995683884670090 }
+    cdf_points { value: 1053, cdf: 0.8657363659283180413 }
+    cdf_points { value: 1084, cdf: 0.8682731634681699617 }
+    cdf_points { value: 1117, cdf: 0.8708099610080209940 }
+    cdf_points { value: 1152, cdf: 0.8733467585478720263 }
+    cdf_points { value: 1189, cdf: 0.8758835560877229476 }
+    cdf_points { value: 1229, cdf: 0.8784203536275739799 }
+    cdf_points { value: 1271, cdf: 0.8809571511674250122 }
+    cdf_points { value: 1317, cdf: 0.8834939487072760445 }
+    cdf_points { value: 1365, cdf: 0.8860307462471279649 }
+    cdf_points { value: 1418, cdf: 0.8885675437869789972 }
+    cdf_points { value: 1475, cdf: 0.8911043413268300295 }
+    cdf_points { value: 1536, cdf: 0.8936411388666809508 }
+    cdf_points { value: 1603, cdf: 0.8961779364065319831 }
+    cdf_points { value: 1676, cdf: 0.8987147339463830154 }
+    cdf_points { value: 1755, cdf: 0.9012515314862340476 }
+    cdf_points { value: 1843, cdf: 0.9037883290260859681 }
+    cdf_points { value: 1940, cdf: 0.9063251265659370004 }
+    cdf_points { value: 2048, cdf: 0.9088619241057880327 }
+    cdf_points { value: 2185, cdf: 0.9121235147643439456 }
+    cdf_points { value: 2341, cdf: 0.9153851054228999695 }
+    cdf_points { value: 2521, cdf: 0.9186466960814549942 }
+    cdf_points { value: 2731, cdf: 0.9219082867400110182 }
+    cdf_points { value: 2979, cdf: 0.9251698773985670421 }
+    cdf_points { value: 3277, cdf: 0.9284314680571229550 }
+    cdf_points { value: 3641, cdf: 0.9316930587156789789 }
+    cdf_points { value: 4096, cdf: 0.9349546493742350028 }
+    cdf_points { value: 4304, cdf: 0.9377953992269539851 }
+    cdf_points { value: 4535, cdf: 0.9406361490796739666 }
+    cdf_points { value: 4792, cdf: 0.9434768989323929489 }
+    cdf_points { value: 5079, cdf: 0.9463176487851120422 }
+    cdf_points { value: 5403, cdf: 0.9491583986378320237 }
+    cdf_points { value: 5772, cdf: 0.9519991484905510060 }
+    cdf_points { value: 6194, cdf: 0.9548398983432709874 }
+    cdf_points { value: 6683, cdf: 0.9576806481959899697 }
+    cdf_points { value: 7256, cdf: 0.9605213980487099512 }
+    cdf_points { value: 7936, cdf: 0.9633621479014290445 }
+    cdf_points { value: 8612, cdf: 0.9662978427235480172 }
+    cdf_points { value: 9330, cdf: 0.9692810100303670406 }
+    cdf_points { value: 10178, cdf: 0.9722641773371859530 }
+    cdf_points { value: 11196, cdf: 0.9752473446440049765 }
+    cdf_points { value: 12440, cdf: 0.9782305119508239999 }
+    cdf_points { value: 13995, cdf: 0.9812136792576430233 }
+    cdf_points { value: 15994, cdf: 0.9841968465644620467 }
+    cdf_points { value: 19085, cdf: 0.9863094546433339715 }
+    cdf_points { value: 22851, cdf: 0.9879248681710689484 }
+    cdf_points { value: 27136, cdf: 0.9892171989932579956 }
+    cdf_points { value: 32161, cdf: 0.9902941413450809804 }
+    cdf_points { value: 38322, cdf: 0.9912290503258339713 }
+    cdf_points { value: 45677, cdf: 0.9920149043341269790 }
+    cdf_points { value: 54482, cdf: 0.9926766761305829689 }
+    cdf_points { value: 64600, cdf: 0.9932143657152040506 }
+    cdf_points { value: 77101, cdf: 0.9944176704619349660 }
+    cdf_points { value: 92160, cdf: 0.9954935445447610221 }
+    cdf_points { value: 110247, cdf: 0.9963972787743350379 }
+    cdf_points { value: 132192, cdf: 0.9971513177203079614 }
+    cdf_points { value: 157821, cdf: 0.9975777645436939567 }
+    cdf_points { value: 188616, cdf: 0.9979368776581239997 }
+    cdf_points { value: 225788, cdf: 0.9982398793484249522 }
+    cdf_points { value: 270088, cdf: 0.9985145808292960057 }
+    cdf_points { value: 323452, cdf: 0.9988492947614909800 }
+    cdf_points { value: 387517, cdf: 0.9991293615210830037 }
+    cdf_points { value: 463677, cdf: 0.9993616120046470153 }
+    cdf_points { value: 553844, cdf: 0.9995259659698350063 }
+    cdf_points { value: 662487, cdf: 0.9996066526132679764 }
+    cdf_points { value: 793885, cdf: 0.9996747319686639655 }
+    cdf_points { value: 946917, cdf: 0.9997302040360229736 }
+    cdf_points { value: 1000000, cdf: 1.0000000000000000000 }
+  }
+}

--- a/homa_experiments/homa_test_w4.config
+++ b/homa_experiments/homa_test_w4.config
@@ -1,0 +1,275 @@
+tests {
+  attributes: { key: 'workload' value: 'w4' }
+  attributes: { key: 'max_message_length' value: '1000000' }
+  attributes: { key: 'min_bucket_frac' value: '0.0025' }
+  attributes: { key: 'max_size_ratio' value: '1.2' }
+  attributes: { key: 'Gbps' value: '20' }
+  attributes: { key: 'num_nodes' value: '10' }
+  attributes: { key: 'test_duration_s' value: '10' }
+  protocol_driver_options {
+    name: 'default_protocol_driver_options'
+    protocol_name: 'homa'
+  }
+  name: 'homa_test'
+  services {
+    name: 'clique'
+    count: 10
+  }
+  action_lists {
+    name: 'clique'
+    action_names: 'clique_queries'
+  }
+  actions {
+    name: 'clique_queries'
+    iterations {
+      max_duration_us: 10000000
+      open_loop_interval_ns: 24404
+      open_loop_interval_distribution: 'exponential_distribution'
+      warmup_iterations: 1500
+    }
+    rpc_name: 'clique_query'
+  }
+  rpc_descriptions {
+    name: 'clique_query'
+    client: 'clique'
+    server: 'clique'
+    fanout_filter: 'random'
+    distribution_config_name: "dist_config"
+  }
+  action_lists {
+    name: 'clique_query'
+    # no actions, NOP
+  }
+  overload_limits {
+    max_pending_rpcs: 5000
+  }
+  distribution_config {
+    name: "dist_config"
+    field_names: "payload_size"
+    cdf_points { value: 53, cdf: 0.0007400000000000000 }
+    cdf_points { value: 60, cdf: 0.0022200000000000002 }
+    cdf_points { value: 72, cdf: 0.0044400000000000004 }
+    cdf_points { value: 81, cdf: 0.0059199999999999999 }
+    cdf_points { value: 92, cdf: 0.0074000000000000003 }
+    cdf_points { value: 109, cdf: 0.0088999999999999999 }
+    cdf_points { value: 130, cdf: 0.0103999999999999995 }
+    cdf_points { value: 154, cdf: 0.0119000000000000009 }
+    cdf_points { value: 183, cdf: 0.0134000000000000005 }
+    cdf_points { value: 217, cdf: 0.0149000000000000000 }
+    cdf_points { value: 222, cdf: 0.0175000000000000017 }
+    cdf_points { value: 227, cdf: 0.0200999999999999998 }
+    cdf_points { value: 232, cdf: 0.0227000000000000014 }
+    cdf_points { value: 237, cdf: 0.0252999999999999996 }
+    cdf_points { value: 243, cdf: 0.0279000000000000012 }
+    cdf_points { value: 248, cdf: 0.0304999999999999993 }
+    cdf_points { value: 254, cdf: 0.0330999999999999975 }
+    cdf_points { value: 259, cdf: 0.0357000000000000026 }
+    cdf_points { value: 265, cdf: 0.0383000000000000007 }
+    cdf_points { value: 271, cdf: 0.0408999999999999989 }
+    cdf_points { value: 279, cdf: 0.0442299999999999985 }
+    cdf_points { value: 288, cdf: 0.0475599999999999981 }
+    cdf_points { value: 297, cdf: 0.0508899999999999977 }
+    cdf_points { value: 303, cdf: 0.0605499999999999997 }
+    cdf_points { value: 305, cdf: 0.0690999999999999948 }
+    cdf_points { value: 308, cdf: 0.0776499999999999968 }
+    cdf_points { value: 310, cdf: 0.0861999999999999988 }
+    cdf_points { value: 313, cdf: 0.0947500000000000009 }
+    cdf_points { value: 315, cdf: 0.1033000000000000029 }
+    cdf_points { value: 318, cdf: 0.1118500000000000050 }
+    cdf_points { value: 321, cdf: 0.1203999999999999931 }
+    cdf_points { value: 323, cdf: 0.1289500000000000091 }
+    cdf_points { value: 326, cdf: 0.1375000000000000111 }
+    cdf_points { value: 331, cdf: 0.1440099999999999991 }
+    cdf_points { value: 335, cdf: 0.1505199999999999871 }
+    cdf_points { value: 340, cdf: 0.1570300000000000029 }
+    cdf_points { value: 345, cdf: 0.1635399999999999909 }
+    cdf_points { value: 350, cdf: 0.1700500000000000067 }
+    cdf_points { value: 355, cdf: 0.1765599999999999947 }
+    cdf_points { value: 360, cdf: 0.1830700000000000105 }
+    cdf_points { value: 365, cdf: 0.1895799999999999985 }
+    cdf_points { value: 371, cdf: 0.1960899999999999865 }
+    cdf_points { value: 376, cdf: 0.2026000000000000023 }
+    cdf_points { value: 385, cdf: 0.2066800000000000026 }
+    cdf_points { value: 395, cdf: 0.2107600000000000029 }
+    cdf_points { value: 405, cdf: 0.2148400000000000032 }
+    cdf_points { value: 415, cdf: 0.2189200000000000035 }
+    cdf_points { value: 425, cdf: 0.2230000000000000038 }
+    cdf_points { value: 430, cdf: 0.2270899999999999863 }
+    cdf_points { value: 435, cdf: 0.2311799999999999966 }
+    cdf_points { value: 441, cdf: 0.2352700000000000069 }
+    cdf_points { value: 446, cdf: 0.2393599999999999894 }
+    cdf_points { value: 452, cdf: 0.2434499999999999997 }
+    cdf_points { value: 457, cdf: 0.2475400000000000100 }
+    cdf_points { value: 463, cdf: 0.2516300000000000203 }
+    cdf_points { value: 468, cdf: 0.2557200000000000029 }
+    cdf_points { value: 474, cdf: 0.2598099999999999854 }
+    cdf_points { value: 480, cdf: 0.2639000000000000234 }
+    cdf_points { value: 491, cdf: 0.2834200000000000053 }
+    cdf_points { value: 502, cdf: 0.3029399999999999871 }
+    cdf_points { value: 513, cdf: 0.3224600000000000244 }
+    cdf_points { value: 525, cdf: 0.3419800000000000062 }
+    cdf_points { value: 537, cdf: 0.3614999999999999880 }
+    cdf_points { value: 549, cdf: 0.3810200000000000253 }
+    cdf_points { value: 561, cdf: 0.4005400000000000071 }
+    cdf_points { value: 574, cdf: 0.4200599999999999890 }
+    cdf_points { value: 587, cdf: 0.4395800000000000263 }
+    cdf_points { value: 600, cdf: 0.4591000000000000081 }
+    cdf_points { value: 607, cdf: 0.4648599999999999954 }
+    cdf_points { value: 615, cdf: 0.4706199999999999828 }
+    cdf_points { value: 623, cdf: 0.4763800000000000257 }
+    cdf_points { value: 630, cdf: 0.4821400000000000130 }
+    cdf_points { value: 638, cdf: 0.4879000000000000004 }
+    cdf_points { value: 646, cdf: 0.4936599999999999877 }
+    cdf_points { value: 654, cdf: 0.4994199999999999751 }
+    cdf_points { value: 662, cdf: 0.5051799999999999624 }
+    cdf_points { value: 671, cdf: 0.5109399999999999498 }
+    cdf_points { value: 679, cdf: 0.5167000000000000481 }
+    cdf_points { value: 685, cdf: 0.5202299999999999702 }
+    cdf_points { value: 690, cdf: 0.5237600000000000033 }
+    cdf_points { value: 696, cdf: 0.5272900000000000365 }
+    cdf_points { value: 702, cdf: 0.5308199999999999585 }
+    cdf_points { value: 707, cdf: 0.5343499999999999917 }
+    cdf_points { value: 713, cdf: 0.5378800000000000248 }
+    cdf_points { value: 719, cdf: 0.5414099999999999469 }
+    cdf_points { value: 725, cdf: 0.5449399999999999800 }
+    cdf_points { value: 731, cdf: 0.5484700000000000131 }
+    cdf_points { value: 737, cdf: 0.5520000000000000462 }
+    cdf_points { value: 749, cdf: 0.5568400000000000016 }
+    cdf_points { value: 762, cdf: 0.5616799999999999571 }
+    cdf_points { value: 774, cdf: 0.5665200000000000236 }
+    cdf_points { value: 787, cdf: 0.5713599999999999790 }
+    cdf_points { value: 800, cdf: 0.5762000000000000455 }
+    cdf_points { value: 816, cdf: 0.5792000000000000481 }
+    cdf_points { value: 833, cdf: 0.5822000000000000508 }
+    cdf_points { value: 850, cdf: 0.5852000000000000535 }
+    cdf_points { value: 867, cdf: 0.5881999999999999451 }
+    cdf_points { value: 885, cdf: 0.5911999999999999478 }
+    cdf_points { value: 914, cdf: 0.5948999999999999844 }
+    cdf_points { value: 945, cdf: 0.5986000000000000210 }
+    cdf_points { value: 976, cdf: 0.6022999999999999465 }
+    cdf_points { value: 1009, cdf: 0.6059999999999999831 }
+    cdf_points { value: 1042, cdf: 0.6097000000000000197 }
+    cdf_points { value: 1085, cdf: 0.6133999999999999453 }
+    cdf_points { value: 1130, cdf: 0.6170999999999999819 }
+    cdf_points { value: 1177, cdf: 0.6208000000000000185 }
+    cdf_points { value: 1226, cdf: 0.6245000000000000551 }
+    cdf_points { value: 1277, cdf: 0.6281999999999999806 }
+    cdf_points { value: 1316, cdf: 0.6315600000000000103 }
+    cdf_points { value: 1357, cdf: 0.6349200000000000399 }
+    cdf_points { value: 1399, cdf: 0.6382799999999999585 }
+    cdf_points { value: 1436, cdf: 0.6408800000000000052 }
+    cdf_points { value: 1484, cdf: 0.6438399999999999679 }
+    cdf_points { value: 1534, cdf: 0.6468000000000000416 }
+    cdf_points { value: 1559, cdf: 0.6509000000000000341 }
+    cdf_points { value: 1585, cdf: 0.6550000000000000266 }
+    cdf_points { value: 1611, cdf: 0.6591000000000000192 }
+    cdf_points { value: 1637, cdf: 0.6632000000000000117 }
+    cdf_points { value: 1664, cdf: 0.6673000000000000043 }
+    cdf_points { value: 1865, cdf: 0.6702599999999999669 }
+    cdf_points { value: 2091, cdf: 0.6732200000000000406 }
+    cdf_points { value: 2412, cdf: 0.6765600000000000502 }
+    cdf_points { value: 2742, cdf: 0.6793500000000000094 }
+    cdf_points { value: 3118, cdf: 0.6821399999999999686 }
+    cdf_points { value: 3544, cdf: 0.6849300000000000388 }
+    cdf_points { value: 4030, cdf: 0.6877199999999999980 }
+    cdf_points { value: 4582, cdf: 0.6905099999999999572 }
+    cdf_points { value: 5210, cdf: 0.6933000000000000274 }
+    cdf_points { value: 5652, cdf: 0.6962800000000000100 }
+    cdf_points { value: 6132, cdf: 0.6992599999999999927 }
+    cdf_points { value: 6653, cdf: 0.7022399999999999753 }
+    cdf_points { value: 7217, cdf: 0.7052199999999999580 }
+    cdf_points { value: 7830, cdf: 0.7082000000000000517 }
+    cdf_points { value: 9012, cdf: 0.7095000000000000195 }
+    cdf_points { value: 10373, cdf: 0.7107999999999999874 }
+    cdf_points { value: 11939, cdf: 0.7120999999999999552 }
+    cdf_points { value: 13741, cdf: 0.7134000000000000341 }
+    cdf_points { value: 15816, cdf: 0.7147000000000000020 }
+    cdf_points { value: 18203, cdf: 0.7159999999999999698 }
+    cdf_points { value: 20952, cdf: 0.7173000000000000487 }
+    cdf_points { value: 24115, cdf: 0.7186000000000000165 }
+    cdf_points { value: 27756, cdf: 0.7198999999999999844 }
+    cdf_points { value: 32871, cdf: 0.7230600000000000360 }
+    cdf_points { value: 34308, cdf: 0.7258499999999999952 }
+    cdf_points { value: 35808, cdf: 0.7286399999999999544 }
+    cdf_points { value: 37146, cdf: 0.7314300000000000246 }
+    cdf_points { value: 38065, cdf: 0.7342199999999999838 }
+    cdf_points { value: 39007, cdf: 0.7370100000000000540 }
+    cdf_points { value: 39973, cdf: 0.7398000000000000131 }
+    cdf_points { value: 40796, cdf: 0.7435199999999999587 }
+    cdf_points { value: 41636, cdf: 0.7472400000000000153 }
+    cdf_points { value: 42493, cdf: 0.7509599999999999609 }
+    cdf_points { value: 43367, cdf: 0.7546800000000000175 }
+    cdf_points { value: 44260, cdf: 0.7583999999999999631 }
+    cdf_points { value: 44804, cdf: 0.7624800000000000466 }
+    cdf_points { value: 45356, cdf: 0.7665600000000000191 }
+    cdf_points { value: 45913, cdf: 0.7706399999999999917 }
+    cdf_points { value: 46478, cdf: 0.7747199999999999642 }
+    cdf_points { value: 47050, cdf: 0.7788000000000000478 }
+    cdf_points { value: 47435, cdf: 0.7825199999999999934 }
+    cdf_points { value: 47823, cdf: 0.7862400000000000500 }
+    cdf_points { value: 48215, cdf: 0.7899599999999999955 }
+    cdf_points { value: 48609, cdf: 0.7936800000000000521 }
+    cdf_points { value: 49007, cdf: 0.7973999999999999977 }
+    cdf_points { value: 49408, cdf: 0.8011200000000000543 }
+    cdf_points { value: 49813, cdf: 0.8048399999999999999 }
+    cdf_points { value: 50221, cdf: 0.8085599999999999454 }
+    cdf_points { value: 50632, cdf: 0.8122800000000000020 }
+    cdf_points { value: 51046, cdf: 0.8159999999999999476 }
+    cdf_points { value: 55381, cdf: 0.8189600000000000213 }
+    cdf_points { value: 60084, cdf: 0.8219199999999999839 }
+    cdf_points { value: 64132, cdf: 0.8252599999999999936 }
+    cdf_points { value: 66528, cdf: 0.8280499999999999527 }
+    cdf_points { value: 69014, cdf: 0.8308400000000000230 }
+    cdf_points { value: 71156, cdf: 0.8336299999999999821 }
+    cdf_points { value: 72473, cdf: 0.8364200000000000523 }
+    cdf_points { value: 73814, cdf: 0.8392100000000000115 }
+    cdf_points { value: 75180, cdf: 0.8419999999999999707 }
+    cdf_points { value: 75795, cdf: 0.8449699999999999989 }
+    cdf_points { value: 76416, cdf: 0.8479400000000000270 }
+    cdf_points { value: 77041, cdf: 0.8509100000000000552 }
+    cdf_points { value: 77672, cdf: 0.8538799999999999724 }
+    cdf_points { value: 78307, cdf: 0.8568500000000000005 }
+    cdf_points { value: 78948, cdf: 0.8598200000000000287 }
+    cdf_points { value: 79595, cdf: 0.8627899999999999459 }
+    cdf_points { value: 80246, cdf: 0.8657599999999999740 }
+    cdf_points { value: 80903, cdf: 0.8687300000000000022 }
+    cdf_points { value: 81565, cdf: 0.8717000000000000304 }
+    cdf_points { value: 85305, cdf: 0.8750599999999999490 }
+    cdf_points { value: 89216, cdf: 0.8784199999999999786 }
+    cdf_points { value: 93306, cdf: 0.8817800000000000082 }
+    cdf_points { value: 97584, cdf: 0.8851400000000000379 }
+    cdf_points { value: 102058, cdf: 0.8884999999999999565 }
+    cdf_points { value: 105871, cdf: 0.8912900000000000267 }
+    cdf_points { value: 109826, cdf: 0.8940799999999999859 }
+    cdf_points { value: 113929, cdf: 0.8968699999999999450 }
+    cdf_points { value: 118669, cdf: 0.8996399999999999952 }
+    cdf_points { value: 123857, cdf: 0.9023999999999999799 }
+    cdf_points { value: 129272, cdf: 0.9051599999999999646 }
+    cdf_points { value: 135199, cdf: 0.9079399999999999693 }
+    cdf_points { value: 141975, cdf: 0.9107600000000000140 }
+    cdf_points { value: 149091, cdf: 0.9135799999999999477 }
+    cdf_points { value: 156563, cdf: 0.9163999999999999924 }
+    cdf_points { value: 164410, cdf: 0.9191899999999999515 }
+    cdf_points { value: 172651, cdf: 0.9219800000000000217 }
+    cdf_points { value: 181304, cdf: 0.9247699999999999809 }
+    cdf_points { value: 189618, cdf: 0.9275400000000000311 }
+    cdf_points { value: 197911, cdf: 0.9303000000000000158 }
+    cdf_points { value: 206566, cdf: 0.9330600000000000005 }
+    cdf_points { value: 215160, cdf: 0.9358300000000000507 }
+    cdf_points { value: 223195, cdf: 0.9386200000000000099 }
+    cdf_points { value: 231530, cdf: 0.9414099999999999691 }
+    cdf_points { value: 240177, cdf: 0.9442000000000000393 }
+    cdf_points { value: 253761, cdf: 0.9469899999999999984 }
+    cdf_points { value: 268113, cdf: 0.9497799999999999576 }
+    cdf_points { value: 283277, cdf: 0.9525700000000000278 }
+    cdf_points { value: 318166, cdf: 0.9553599999999999870 }
+    cdf_points { value: 368444, cdf: 0.9581499999999999462 }
+    cdf_points { value: 426666, cdf: 0.9609400000000000164 }
+    cdf_points { value: 492079, cdf: 0.9633599999999999941 }
+    cdf_points { value: 588723, cdf: 0.9656000000000000139 }
+    cdf_points { value: 704348, cdf: 0.9678400000000000336 }
+    cdf_points { value: 832442, cdf: 0.9702499999999999458 }
+    cdf_points { value: 940700, cdf: 0.9720999999999999641 }
+    cdf_points { value: 1000000, cdf: 1.0000000000000000000 }
+  }
+}

--- a/homa_experiments/homa_test_w5.config
+++ b/homa_experiments/homa_test_w5.config
@@ -1,0 +1,159 @@
+tests {
+  attributes: { key: 'workload' value: 'w5' }
+  attributes: { key: 'max_message_length' value: '1000000' }
+  attributes: { key: 'min_bucket_frac' value: '0.0025' }
+  attributes: { key: 'max_size_ratio' value: '1.2' }
+  attributes: { key: 'Gbps' value: '20' }
+  attributes: { key: 'num_nodes' value: '10' }
+  attributes: { key: 'test_duration_s' value: '10' }
+  protocol_driver_options {
+    name: 'default_protocol_driver_options'
+    protocol_name: 'homa'
+  }
+  name: 'homa_test'
+  services {
+    name: 'clique'
+    count: 10
+  }
+  action_lists {
+    name: 'clique'
+    action_names: 'clique_queries'
+  }
+  actions {
+    name: 'clique_queries'
+    iterations {
+      max_duration_us: 10000000
+      open_loop_interval_ns: 154465
+      open_loop_interval_distribution: 'exponential_distribution'
+      warmup_iterations: 1500
+    }
+    rpc_name: 'clique_query'
+  }
+  rpc_descriptions {
+    name: 'clique_query'
+    client: 'clique'
+    server: 'clique'
+    fanout_filter: 'random'
+    distribution_config_name: "dist_config"
+  }
+  action_lists {
+    name: 'clique_query'
+    # no actions, NOP
+  }
+  overload_limits {
+    max_pending_rpcs: 5000
+  }
+  distribution_config {
+    name: "dist_config"
+    field_names: "payload_size"
+    cdf_points { value: 1430, cdf: 0.0250000000000000014 }
+    cdf_points { value: 2860, cdf: 0.0500000000000000028 }
+    cdf_points { value: 4290, cdf: 0.0749999999999999972 }
+    cdf_points { value: 5720, cdf: 0.1000000000000000056 }
+    cdf_points { value: 7150, cdf: 0.1250000000000000000 }
+    cdf_points { value: 8580, cdf: 0.1499999999999999944 }
+    cdf_points { value: 10010, cdf: 0.1571430000000000049 }
+    cdf_points { value: 11440, cdf: 0.1642859999999999876 }
+    cdf_points { value: 13230, cdf: 0.1714289999999999980 }
+    cdf_points { value: 14700, cdf: 0.1785710000000000075 }
+    cdf_points { value: 16170, cdf: 0.1857139999999999902 }
+    cdf_points { value: 17640, cdf: 0.1928570000000000007 }
+    cdf_points { value: 19110, cdf: 0.2000000000000000111 }
+    cdf_points { value: 20580, cdf: 0.2166669999999999985 }
+    cdf_points { value: 22050, cdf: 0.2333330000000000126 }
+    cdf_points { value: 23520, cdf: 0.2500000000000000000 }
+    cdf_points { value: 24990, cdf: 0.2666669999999999874 }
+    cdf_points { value: 26460, cdf: 0.2833330000000000015 }
+    cdf_points { value: 27930, cdf: 0.2999999999999999889 }
+    cdf_points { value: 29400, cdf: 0.3071429999999999993 }
+    cdf_points { value: 30870, cdf: 0.3142860000000000098 }
+    cdf_points { value: 32340, cdf: 0.3214290000000000203 }
+    cdf_points { value: 33810, cdf: 0.3285710000000000020 }
+    cdf_points { value: 35280, cdf: 0.3357140000000000124 }
+    cdf_points { value: 36750, cdf: 0.3428570000000000229 }
+    cdf_points { value: 38220, cdf: 0.3499999999999999778 }
+    cdf_points { value: 39690, cdf: 0.3571429999999999882 }
+    cdf_points { value: 41160, cdf: 0.3642859999999999987 }
+    cdf_points { value: 42630, cdf: 0.3714290000000000092 }
+    cdf_points { value: 44100, cdf: 0.3785709999999999908 }
+    cdf_points { value: 45570, cdf: 0.3857140000000000013 }
+    cdf_points { value: 47040, cdf: 0.3928570000000000118 }
+    cdf_points { value: 48510, cdf: 0.4000000000000000222 }
+    cdf_points { value: 49980, cdf: 0.4064999999999999725 }
+    cdf_points { value: 51450, cdf: 0.4129999999999999782 }
+    cdf_points { value: 52920, cdf: 0.4194999999999999840 }
+    cdf_points { value: 54390, cdf: 0.4259999999999999898 }
+    cdf_points { value: 55860, cdf: 0.4324999999999999956 }
+    cdf_points { value: 57330, cdf: 0.4390000000000000013 }
+    cdf_points { value: 58800, cdf: 0.4455000000000000071 }
+    cdf_points { value: 60270, cdf: 0.4520000000000000129 }
+    cdf_points { value: 61740, cdf: 0.4585000000000000187 }
+    cdf_points { value: 63210, cdf: 0.4650000000000000244 }
+    cdf_points { value: 64680, cdf: 0.4714999999999999747 }
+    cdf_points { value: 66150, cdf: 0.4779999999999999805 }
+    cdf_points { value: 67620, cdf: 0.4844999999999999862 }
+    cdf_points { value: 69090, cdf: 0.4909999999999999920 }
+    cdf_points { value: 70560, cdf: 0.4974999999999999978 }
+    cdf_points { value: 72030, cdf: 0.5040000000000000036 }
+    cdf_points { value: 73500, cdf: 0.5104999999999999538 }
+    cdf_points { value: 74970, cdf: 0.5170000000000000151 }
+    cdf_points { value: 76440, cdf: 0.5234999999999999654 }
+    cdf_points { value: 77910, cdf: 0.5300000000000000266 }
+    cdf_points { value: 82320, cdf: 0.5326250000000000151 }
+    cdf_points { value: 86730, cdf: 0.5352500000000000036 }
+    cdf_points { value: 91140, cdf: 0.5378749999999999920 }
+    cdf_points { value: 95550, cdf: 0.5404999999999999805 }
+    cdf_points { value: 99960, cdf: 0.5431249999999999689 }
+    cdf_points { value: 104370, cdf: 0.5457499999999999574 }
+    cdf_points { value: 108780, cdf: 0.5483749999999999458 }
+    cdf_points { value: 113190, cdf: 0.5510000000000000453 }
+    cdf_points { value: 117600, cdf: 0.5536250000000000338 }
+    cdf_points { value: 122010, cdf: 0.5562500000000000222 }
+    cdf_points { value: 126420, cdf: 0.5588750000000000107 }
+    cdf_points { value: 130830, cdf: 0.5614999999999999991 }
+    cdf_points { value: 135240, cdf: 0.5641249999999999876 }
+    cdf_points { value: 139650, cdf: 0.5667499999999999760 }
+    cdf_points { value: 144060, cdf: 0.5693749999999999645 }
+    cdf_points { value: 148470, cdf: 0.5719999999999999529 }
+    cdf_points { value: 152880, cdf: 0.5746250000000000524 }
+    cdf_points { value: 157290, cdf: 0.5772500000000000409 }
+    cdf_points { value: 161700, cdf: 0.5798750000000000293 }
+    cdf_points { value: 166110, cdf: 0.5825000000000000178 }
+    cdf_points { value: 170520, cdf: 0.5851250000000000062 }
+    cdf_points { value: 174930, cdf: 0.5877499999999999947 }
+    cdf_points { value: 179340, cdf: 0.5903749999999999831 }
+    cdf_points { value: 183750, cdf: 0.5929999999999999716 }
+    cdf_points { value: 188160, cdf: 0.5956249999999999600 }
+    cdf_points { value: 192570, cdf: 0.5982499999999999485 }
+    cdf_points { value: 202860, cdf: 0.6009360000000000257 }
+    cdf_points { value: 223440, cdf: 0.6035580000000000389 }
+    cdf_points { value: 244020, cdf: 0.6061800000000000521 }
+    cdf_points { value: 264600, cdf: 0.6088010000000000366 }
+    cdf_points { value: 285180, cdf: 0.6114230000000000498 }
+    cdf_points { value: 305760, cdf: 0.6140449999999999520 }
+    cdf_points { value: 326340, cdf: 0.6166669999999999652 }
+    cdf_points { value: 346920, cdf: 0.6192879999999999496 }
+    cdf_points { value: 373380, cdf: 0.6226589999999999625 }
+    cdf_points { value: 411600, cdf: 0.6275279999999999747 }
+    cdf_points { value: 432180, cdf: 0.6301499999999999879 }
+    cdf_points { value: 470400, cdf: 0.6350190000000000001 }
+    cdf_points { value: 490980, cdf: 0.6376399999999999846 }
+    cdf_points { value: 529200, cdf: 0.6425089999999999968 }
+    cdf_points { value: 549780, cdf: 0.6451310000000000100 }
+    cdf_points { value: 588000, cdf: 0.6500000000000000222 }
+    cdf_points { value: 608580, cdf: 0.6526220000000000354 }
+    cdf_points { value: 648270, cdf: 0.6576779999999999848 }
+    cdf_points { value: 686490, cdf: 0.6625469999999999970 }
+    cdf_points { value: 707070, cdf: 0.6651690000000000103 }
+    cdf_points { value: 745290, cdf: 0.6700369999999999937 }
+    cdf_points { value: 765870, cdf: 0.6726590000000000069 }
+    cdf_points { value: 804090, cdf: 0.6775280000000000191 }
+    cdf_points { value: 824670, cdf: 0.6801500000000000323 }
+    cdf_points { value: 862890, cdf: 0.6850190000000000445 }
+    cdf_points { value: 883470, cdf: 0.6876400000000000290 }
+    cdf_points { value: 921690, cdf: 0.6925090000000000412 }
+    cdf_points { value: 942270, cdf: 0.6951310000000000544 }
+    cdf_points { value: 980490, cdf: 0.6999999999999999556 }
+    cdf_points { value: 1000000, cdf: 1.0000000000000000000 }
+  }
+}


### PR DESCRIPTION
Added config files that contain distribution_configs that represent the workloads (w1-w5) from HomaModule. Proto files were generated with default setting from cp_node and Gbps values that make open_loop_interval >= 100 ms with a min of 1 Gbps and a max of 20 Gbps. W1 and w2 are generated with 1 Gbps, w3 is generated with 2 Gbps, w4 and w5 are generated with 20 Gbps. Milliseconds are computed in HomaModule/util/dist_to_proto.cc. 