### PR TITLE
Debugging homa PD

### DIFF
--- a/protocol_driver_homa.cc
+++ b/protocol_driver_homa.cc
@@ -290,6 +290,7 @@ void ProtocolDriverHoma::InitiateRpc(int peer_index, ClientRpcState* state,
     LOG(INFO) << "homa_send result: " << res << " errno: " << errno
               << " kernel_rpc_number " << kernel_rpc_number;
     delete new_rpc;
+    --pending_rpcs_;
     state->success = false;
     done_callback();
   }


### PR DESCRIPTION
Fixed a bug that caused homa tests on distbench to never create results after traffic was canceled because RPCs with errors were deleted but never decremented the number of pending RPCs which caused the program to stall.